### PR TITLE
Adding support for focus and blur events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -33,6 +33,16 @@ selectize.off('event_name', handler);
 		<td valign="top">Invoked when the value of the control changes.</td>
 	</tr>
 	<tr>
+		<td valign="top"><code>"focus"</code></td>
+		<td valign="top"></td>
+		<td valign="top">Invoked when the control gains focus.</td>
+	</tr>
+	<tr>
+		<td valign="top"><code>"blur"</code></td>
+		<td valign="top"></td>
+		<td valign="top">Invoked when the control loses focus.</td>
+	</tr>
+	<tr>
 		<td valign="top"><code>"item_add"</code></td>
 		<td valign="top">value, $item</td>
 		<td valign="top">Invoked when an item is selected.</td>

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -280,7 +280,9 @@ $.extend(Selectize.prototype, {
 			'option_clear'   : 'onOptionClear',
 			'dropdown_open'  : 'onDropdownOpen',
 			'dropdown_close' : 'onDropdownClose',
-			'type'           : 'onType'
+			'type'           : 'onType',
+			'focus'          : 'onFocus',
+			'blur'           : 'onBlur'
 		};
 
 		for (key in callbacks) {
@@ -489,7 +491,8 @@ $.extend(Selectize.prototype, {
 	 */
 	onFocus: function(e) {
 		var self = this;
-
+		var wasFocused = self.isFocused;
+		
 		self.isFocused = true;
 		if (self.isDisabled) {
 			self.blur();
@@ -499,6 +502,8 @@ $.extend(Selectize.prototype, {
 
 		if (self.ignoreFocus) return;
 		if (self.settings.preload === 'focus') self.onSearchChange('');
+
+		if (!wasFocused) self.trigger('focus');
 
 		if (!self.$activeItems.length) {
 			self.showInput();
@@ -517,8 +522,12 @@ $.extend(Selectize.prototype, {
 	 */
 	onBlur: function(e) {
 		var self = this;
+		var wasFocused = self.isFocused;
+
 		self.isFocused = false;
 		if (self.ignoreFocus) return;
+
+		if (wasFocused) self.trigger('blur');
 
 		self.close();
 		self.setTextboxValue('');


### PR DESCRIPTION
Hi,

First of all, thanks for your great work on this!

I added support for focus and blur events on the control. It watches the previous state of the .isFocused boolean to ensure the event is only fired when the focus state changes, rather than when the internal focus event is called.

I've got a use case where I want to clear the value on focus, then reset it on blur unless it has been changed, which makes selectize work more like the URL bar in a browser.

But I expect it will be useful for other cases as well, including more sophisticated interaction with other UI controls, etc.

Cheers,
Jed.
