### PR TITLE
Add support for multiple delimiters

### DIFF
--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -18,12 +18,12 @@ $.fn.selectize = function(settings_user) {
 		var i, n, values, option, value = $.trim($input.val() || '');
 		if (!value.length) return;
 
-        if ($.isArray(settings.delimiter)) {
-            values = value.split(new RegExp(settings.delimiter.join('|'), 'g'));
-        }
-        else {
-            values = value.split(settings.delimiter);
-        }
+		if ($.isArray(settings.delimiter)) {
+			values = value.split(new RegExp(settings.delimiter.join('|'), 'g'));
+		}
+		else {
+			values = value.split(settings.delimiter);
+		}
 
 		for (i = 0, n = values.length; i < n; i++) {
 			option = {};

--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -18,7 +18,13 @@ $.fn.selectize = function(settings_user) {
 		var i, n, values, option, value = $.trim($input.val() || '');
 		if (!value.length) return;
 
-		values = value.split(settings.delimiter);
+        if ($.isArray(settings.delimiter)) {
+            values = value.split(new RegExp(settings.delimiter.join('|'), 'g'));
+        }
+        else {
+            values = value.split(settings.delimiter);
+        }
+
 		for (i = 0, n = values.length; i < n; i++) {
 			option = {};
 			option[field_label] = values[i];

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -362,11 +362,26 @@ $.extend(Selectize.prototype, {
 	onKeyPress: function(e) {
 		if (this.isLocked) return e && e.preventDefault();
 		var character = String.fromCharCode(e.keyCode || e.which);
-		if (this.settings.create && character === this.settings.delimiter) {
-			this.createItem();
-			e.preventDefault();
-			return false;
-		}
+        if (this.settings.create) {
+            var matchDelimiter;
+            if ($.isArray(this.settings.delimiter)) {
+                for (var i = 0; i < this.settings.delimiter.length; i++) {
+                    if (character === this.settings.delimiter[i]) {
+                        matchDelimiter = true;
+                        break;
+                    }
+                }
+            }
+            else {
+                matchDelimiter = (character === this.settings.delimiter);
+            }
+
+            if(matchDelimiter) {
+                this.createItem();
+                e.preventDefault();
+                return false;
+            }
+        }
 	},
 
 	/**
@@ -638,7 +653,12 @@ $.extend(Selectize.prototype, {
 		if (this.tagType === TAG_SELECT && this.$input.attr('multiple')) {
 			return this.items;
 		} else {
-			return this.items.join(this.settings.delimiter);
+            if($.isArray(this.settings.delimiter)) {
+                return this.items.join(this.settings.delimiter[0]);
+            }
+            else {
+			    return this.items.join(this.settings.delimiter);
+            }
 		}
 	},
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -362,26 +362,26 @@ $.extend(Selectize.prototype, {
 	onKeyPress: function(e) {
 		if (this.isLocked) return e && e.preventDefault();
 		var character = String.fromCharCode(e.keyCode || e.which);
-        if (this.settings.create) {
-            var matchDelimiter;
-            if ($.isArray(this.settings.delimiter)) {
-                for (var i = 0; i < this.settings.delimiter.length; i++) {
-                    if (character === this.settings.delimiter[i]) {
-                        matchDelimiter = true;
-                        break;
-                    }
-                }
-            }
-            else {
-                matchDelimiter = (character === this.settings.delimiter);
-            }
+		if (this.settings.create) {
+			var matchDelimiter;
+			if ($.isArray(this.settings.delimiter)) {
+				for (var i = 0; i < this.settings.delimiter.length; i++) {
+					if (character === this.settings.delimiter[i]) {
+						matchDelimiter = true;
+						break;
+					}
+				}
+			}
+			else {
+				matchDelimiter = (character === this.settings.delimiter);
+			}
 
-            if(matchDelimiter) {
-                this.createItem();
-                e.preventDefault();
-                return false;
-            }
-        }
+			if (matchDelimiter) {
+				this.createItem();
+				e.preventDefault();
+				return false;
+			}
+		}
 	},
 
 	/**
@@ -653,12 +653,12 @@ $.extend(Selectize.prototype, {
 		if (this.tagType === TAG_SELECT && this.$input.attr('multiple')) {
 			return this.items;
 		} else {
-            if($.isArray(this.settings.delimiter)) {
-                return this.items.join(this.settings.delimiter[0]);
-            }
-            else {
-			    return this.items.join(this.settings.delimiter);
-            }
+			if ($.isArray(this.settings.delimiter)) {
+				return this.items.join(this.settings.delimiter[0]);
+			}
+			else {
+				return this.items.join(this.settings.delimiter);
+			}
 		}
 	},
 


### PR DESCRIPTION
If you want to create a "tag selection" component you might expect a behavior where string splits not only at `,` but on other characters like `Space`.

This PR adds the functionality to define multiple delimiters as an array. All given delimiters are considered when splitting the string. The first delimiter is used to concatenate values.

``` javascript
// Usage with one delimiter (100% compatible)
$("#elem").selectize({
    delimiter: ','
});

// Usage with multiple delimiters
$("#elem").selectize({
    delimiter: [',', ' ']
});
```
