### PR TITLE
If array is passed into addOption then respect the insert order

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -1492,14 +1492,18 @@
 		 *
 		 * @param {object} data
 		 */
-		addOption: function(data) {
+		addOption: function(data, order) {
 			var i, n, optgroup, value, self = this;
 	
 			if ($.isArray(data)) {
 				for (i = 0, n = data.length; i < n; i++) {
-					self.addOption(data[i]);
+					self.addOption(data[i], i);
 				}
 				return;
+			}
+
+			if (typeof order !== 'undefined') {
+			  data.$order = order;
 			}
 	
 			value = hash_key(data[self.settings.valueField]);

--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -1493,11 +1493,12 @@
 		 * @param {object} data
 		 */
 		addOption: function(data, order) {
-			var i, n, optgroup, value, self = this;
+			var i, n, optgroup, value, start_order, self = this;
 	
 			if ($.isArray(data)) {
+				start_order = Object.keys(self.options).length
 				for (i = 0, n = data.length; i < n; i++) {
-					self.addOption(data[i], i);
+					self.addOption(data[i], start_order + i);
 				}
 				return;
 			}

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -2076,14 +2076,18 @@
 		 *
 		 * @param {object} data
 		 */
-		addOption: function(data) {
+		addOption: function(data, order) {
 			var i, n, optgroup, value, self = this;
 	
 			if ($.isArray(data)) {
 				for (i = 0, n = data.length; i < n; i++) {
-					self.addOption(data[i]);
+					self.addOption(data[i], i);
 				}
 				return;
+			}
+
+			if (typeof order !== 'undefined') {
+			  data.$order = order;
 			}
 	
 			value = hash_key(data[self.settings.valueField]);

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -2077,11 +2077,12 @@
 		 * @param {object} data
 		 */
 		addOption: function(data, order) {
-			var i, n, optgroup, value, self = this;
+			var i, n, optgroup, value, start_order, self = this;
 	
 			if ($.isArray(data)) {
+				start_order = Object.keys(self.options).length
 				for (i = 0, n = data.length; i < n; i++) {
-					self.addOption(data[i], i);
+					self.addOption(data[i], start_order + i);
 				}
 				return;
 			}

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1050,11 +1050,12 @@ $.extend(Selectize.prototype, {
 	 * @param {object} data
 	 */
 	addOption: function(data, order) {
-		var i, n, optgroup, value, self = this;
+		var i, n, optgroup, value, start_order, self = this;
 
 		if ($.isArray(data)) {
+			start_order = Object.keys(self.options).length
 			for (i = 0, n = data.length; i < n; i++) {
-				self.addOption(data[i], i);
+				self.addOption(data[i], start_order + i);
 			}
 			return;
 		}

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1049,14 +1049,18 @@ $.extend(Selectize.prototype, {
 	 *
 	 * @param {object} data
 	 */
-	addOption: function(data) {
+	addOption: function(data, order) {
 		var i, n, optgroup, value, self = this;
 
 		if ($.isArray(data)) {
 			for (i = 0, n = data.length; i < n; i++) {
-				self.addOption(data[i]);
+				self.addOption(data[i], i);
 			}
 			return;
+		}
+
+		if (typeof order !== 'undefined') {
+		  data.$order = order;
 		}
 
 		value = hash_key(data[self.settings.valueField]);


### PR DESCRIPTION
Here is a jsFiddle demonstrating the problem: http://jsfiddle.net/8H62B/6/

I'm not a great Javascript programmer so if I did something wrong please feel free to point it out.

When addOption is given an array I would like it if it would respect the order of the array. We already have an $order property on the option so I just fill that in with the appropriate value.

I wasn't sure what files I should change so I just changed everything except the minimized versions. This should hopefully fix #218. Any thoughts?
