### PR TITLE
optgroup_columns plugin: subtract scrollbar width from the dropdown content

### DIFF
--- a/src/plugins/optgroup_columns/plugin.js
+++ b/src/plugins/optgroup_columns/plugin.js
@@ -73,7 +73,7 @@ Selectize.define('optgroup_columns', function(options) {
 		}
 
 		if (options.equalizeWidth) {
-			width_parent = self.$dropdown_content.innerWidth();
+			width_parent = self.$dropdown_content.innerWidth() - self.scrollbar_width;
 			width = Math.round(width_parent / n);
 			$optgroups.css({width: width});
 			if (n > 1) {

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -138,6 +138,7 @@ $.extend(Selectize.prototype, {
 		self.$control_input    = $control_input;
 		self.$dropdown         = $dropdown;
 		self.$dropdown_content = $dropdown_content;
+		self.scrollbar_width   = getScrollBarWidth();
 
 		$dropdown.on('mouseenter', '[data-selectable]', function() { return self.onOptionHover.apply(self, arguments); });
 		$dropdown.on('mousedown', '[data-selectable]', function() { return self.onOptionSelect.apply(self, arguments); });

--- a/src/utils.js
+++ b/src/utils.js
@@ -278,6 +278,20 @@ var measureString = function(str, $parent) {
 };
 
 /**
+ * Measures the scroll bar width of the browser in pixel
+ *
+ * @returns {int}
+ */
+
+var getScrollBarWidth = function() {
+  	var $outer = $('<div>').css({visibility: 'hidden', width: 100, overflow: 'scroll'}).appendTo('body'),
+    widthWithScroll = $('<div>').css({width: '100%'}).appendTo($outer).outerWidth();
+    
+    $outer.remove();
+    return 100 - widthWithScroll;
+};
+
+/**
  * Sets up an input to grow horizontally as the user
  * types. If the value is changed manually, you can
  * trigger the "update" handler to resize:


### PR DESCRIPTION
With more than two option groups in 'optgroup_columns' plugin, scroll bar pushes the third and fourth etc groups to another row which could easily fit into the first row. It happens because the width of the drop down content doesn't take into account of the scroll bar width.
Example use of this plugin in http://brianreavis.github.io/selectize.js/ has this problem where 'Audi' group gets pushed to a new row unnecessarily.
To find scroll bar width [this snippet](http://stackoverflow.com/a/19015262/479407) is used. Works fine in Chrome, Firefox and Opera. 
