### PR TITLE
optgroup_columns: set width as percentage

### DIFF
--- a/src/plugins/optgroup_columns/plugin.js
+++ b/src/plugins/optgroup_columns/plugin.js
@@ -73,13 +73,7 @@ Selectize.define('optgroup_columns', function(options) {
 		}
 
 		if (options.equalizeWidth) {
-			width_parent = self.$dropdown_content.innerWidth();
-			width = Math.round(width_parent / n);
-			$optgroups.css({width: width});
-			if (n > 1) {
-				width_last = width_parent - width * (n - 1);
-				$optgroups.eq(n - 1).css({width: width_last});
-			}
+			$optgroups.css({width: Math.floor(100/$optgroups.length) + "%"});
 		}
 	};
 


### PR DESCRIPTION
the calculated width did not take into account the scrollbar, so if a scrollbar exists, the last column flowed onto the next row.
This change sets the column width as a percentage, so the browser can layout the columns on the same row (it rounds the percentage down so that they fit slightly better)
