### PR TITLE
Initialization creates options if not present when `create` is specified

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1290,13 +1290,15 @@ $.extend(Selectize.prototype, {
 				return;
 			}
 
-			if (!self.options.hasOwnProperty(value_keyed)) return;
+			if (!self.options.hasOwnProperty(value_keyed)) {
+				if(!self.isSetup && self.settings.create) {
+					self.createItemBase(value, false);	
+				} else {
+					return;
+				}
+			}
 			if (inputMode === 'single') self.clear();
 			if (inputMode === 'multi' && self.isFull()) return;
-
-			if(!self.isSetup && self.settings.create && !self.options.hasOwnProperty(value_keyed)) {
-				self.createItemBase(value, false);
-			}
 			
 			$item = $(self.render('item', self.options[value_keyed]));
 			self.items.splice(self.caretPos, 0, value_keyed);

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1283,19 +1283,23 @@ $.extend(Selectize.prototype, {
 			var self = this;
 			var inputMode = self.settings.mode;
 			var i, active, value_next;
-			value = hash_key(value);
+			var value_keyed = hash_key(value);
 
-			if (self.items.indexOf(value) !== -1) {
+			if (self.items.indexOf(value_keyed) !== -1) {
 				if (inputMode === 'single') self.close();
 				return;
 			}
 
-			if (!self.options.hasOwnProperty(value)) return;
+			if (!self.options.hasOwnProperty(value_keyed)) return;
 			if (inputMode === 'single') self.clear();
 			if (inputMode === 'multi' && self.isFull()) return;
 
-			$item = $(self.render('item', self.options[value]));
-			self.items.splice(self.caretPos, 0, value);
+			if(!self.isSetup && self.settings.create && !self.options.hasOwnProperty(value_keyed)) {
+				self.addOption({self.settings.valueField : {text : value, value : value} });
+			}
+			
+			$item = $(self.render('item', self.options[value_keyed]));
+			self.items.splice(self.caretPos, 0, value_keyed);
 			self.insertAtCaret($item);
 			self.refreshState();
 
@@ -1304,7 +1308,7 @@ $.extend(Selectize.prototype, {
 
 				// update menu / remove the option (if this is not one item being added as part of series)
 				if (!this.isPending) {
-					$option = self.getOption(value);
+					$option = self.getOption(value_keyed);
 					value_next = self.getAdjacentOption($option, 1).attr('data-value');
 					self.refreshOptions(self.isFocused && inputMode !== 'single');
 					if (value_next) {
@@ -1320,7 +1324,7 @@ $.extend(Selectize.prototype, {
 				}
 
 				self.updatePlaceholder();
-				self.trigger('item_add', value, $item);
+				self.trigger('item_add', value_keyed, $item);
 				self.updateOriginalInput();
 			}
 		});

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1396,7 +1396,6 @@ $.extend(Selectize.prototype, {
 	 */
 	createItemBase: function(input, triggerDropdown) {
 		var self  = this;
-		var input = $.trim(self.$control_input.val() || '');
 		var caret = self.caretPos;
 		if (!input.length) return false;
 		self.lock();

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1292,7 +1292,7 @@ $.extend(Selectize.prototype, {
 
 			if (!self.options.hasOwnProperty(value_keyed)) {
 				if(!self.isSetup && self.settings.create) {
-					self.createItemBase(value, false);	
+					self.createItemBase(value, false, false);	
 				} else {
 					return;
 				}
@@ -1383,7 +1383,7 @@ $.extend(Selectize.prototype, {
 	 */
 	createItem: function(triggerDropdown) {
 		var self = this;
-		return self.createItemBase($.trim(self.$control_input.val() || ''), triggerDropdown);
+		return self.createItemBase($.trim(self.$control_input.val() || ''), true, triggerDropdown);
 	},
 	
 	/**
@@ -1396,7 +1396,7 @@ $.extend(Selectize.prototype, {
 	 *
 	 * @return {boolean}
 	 */
-	createItemBase: function(input, triggerDropdown) {
+	createItemBase: function(input, updateItemAndCaret, triggerDropdown) {
 		var self  = this;
 		var caret = self.caretPos;
 		if (!input.length) return false;
@@ -1422,8 +1422,10 @@ $.extend(Selectize.prototype, {
 
 			self.setTextboxValue('');
 			self.addOption(data);
-			self.setCaret(caret);
-			self.addItem(value);
+			if(updateItemAndCaret) {
+				self.setCaret(caret);
+				self.addItem(value);
+			}
 			self.refreshOptions(triggerDropdown && self.settings.mode !== 'single');
 		});
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1295,7 +1295,9 @@ $.extend(Selectize.prototype, {
 			if (inputMode === 'multi' && self.isFull()) return;
 
 			if(!self.isSetup && self.settings.create && !self.options.hasOwnProperty(value_keyed)) {
-				self.addOption({self.settings.valueField : {text : value, value : value} });
+				var data = {text : value};
+				data[self.settings.valueField] = value;
+				self.options[value_keyed] = data;
 			}
 			
 			$item = $(self.render('item', self.options[value_keyed]));

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1295,9 +1295,7 @@ $.extend(Selectize.prototype, {
 			if (inputMode === 'multi' && self.isFull()) return;
 
 			if(!self.isSetup && self.settings.create && !self.options.hasOwnProperty(value_keyed)) {
-				var data = {text : value};
-				data[self.settings.valueField] = value;
-				self.options[value_keyed] = data;
+				self.createItemBase(value, false);
 			}
 			
 			$item = $(self.render('item', self.options[value_keyed]));
@@ -1382,6 +1380,21 @@ $.extend(Selectize.prototype, {
 	 * @return {boolean}
 	 */
 	createItem: function(triggerDropdown) {
+		var self = this;
+		return self.createItemBase($.trim(self.$control_input.val() || ''), triggerDropdown);
+	},
+	
+	/**
+	 * Invokes the `create` method provided in the
+	 * selectize options that should provide the data
+	 * for the new item, given the user input.
+	 *
+	 * Once this completes, it will be added
+	 * to the item list.
+	 *
+	 * @return {boolean}
+	 */
+	createItemBase: function(input, triggerDropdown) {
 		var self  = this;
 		var input = $.trim(self.$control_input.val() || '');
 		var caret = self.caretPos;

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1382,14 +1382,13 @@ $.extend(Selectize.prototype, {
 	 * @return {boolean}
 	 */
 	createItem: function(triggerDropdown) {
-		var self = this;
-		return self.createItemBase($.trim(self.$control_input.val() || ''), true, triggerDropdown);
+		return this.createItemBase($.trim(this.$control_input.val() || ''), true, triggerDropdown);
 	},
 	
 	/**
 	 * Invokes the `create` method provided in the
 	 * selectize options that should provide the data
-	 * for the new item, given the user input.
+	 * for the new item, given the input parameter.
 	 *
 	 * Once this completes, it will be added
 	 * to the item list.


### PR DESCRIPTION
To resolve issue https://github.com/brianreavis/selectize.js/issues/454.  Selectize now will not drop a selected `item` because it is not in the `options` array when `create` is `true`.
