### PR TITLE
Clear the selected item when the user types any alphanumeric character

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -485,7 +485,10 @@ $.extend(Selectize.prototype, {
 		}
 
 		if ((self.isFull() || self.isInputHidden) && !(IS_MAC ? e.metaKey : e.ctrlKey)) {
-			e.preventDefault();
+			if (self.isOpen && self.$activeOption) 
+				self.setValue('');
+			else
+				e.preventDefault();
 			return;
 		}
 	},


### PR DESCRIPTION
When the dropdown is configured for single selection and an item has been selected,
this will automatically clear the selected item when the user types to search for a
new item. With the current behavior, the user has to press back space to clear the selected
item. The UI seems to be unresponsive if the user wants to change the
selection unless they hit backspace
