### PR TITLE
Add option text to original select input

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1518,7 +1518,7 @@ $.extend(Selectize.prototype, {
 		if (self.tagType === TAG_SELECT) {
 			options = [];
 			for (i = 0, n = self.items.length; i < n; i++) {
-				options.push('<option value="' + escape_html(self.items[i]) + '" selected="selected"></option>');
+				options.push('<option value="' + escape_html(self.items[i]) + '" selected="selected">' + self.options[self.items[i]].text + '</option>');
 			}
 			if (!options.length && !this.$input.attr('multiple')) {
 				options.push('<option value="" selected="selected"></option>');

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -55,6 +55,7 @@
 						.click($('[data-value="b"]', test.selectize.$dropdown))
 						.delay(0, function() {
 							expect(test.selectize.$input.val()).to.be.equal('b');
+							expect(test.selectize.$input.text()).to.be.equal('B');
 							done();
 						});
 				});


### PR DESCRIPTION
This simply adds the selected option text to the `<option>` tag inside the original `<select>` tag, in order to make Capybara feature specs work that use `have_select` to match on selected options.
