### PR TITLE
Some css discrepancies between selectize and bootstrap 3.2.0

### DIFF
--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -97,6 +97,7 @@
 }
 
 .selectize-input {
+	overflow: inherit;
 	transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
 	-webkit-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
 	min-height: @input-height-base;

--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -97,6 +97,8 @@
 }
 
 .selectize-input {
+	transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+	-webkit-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
 	min-height: @input-height-base;
 
 	&.dropdown-active {
@@ -133,4 +135,29 @@
 	background: none;
 	.selectize-box-shadow(none);
 	.selectize-border-radius(0);
+}
+
+.has-success .selectize-input {
+	border-color: #3c763d;
+	&.focus {
+		box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 6px #67b168;
+	}
+}
+
+.has-warning .selectize-input {
+	border-color: #8a6d3b;
+	&.focus {
+		box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 6px #c0a16b;
+	}
+}
+
+.has-error .selectize-input {
+	border-color: #a94442;
+	&.focus {
+		box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 6px #ce8483;
+	}
+}
+
+.form-group.has-feedback .selectize-control.multi .selectize-input.has-items {
+	padding-right: 42.5px;
 }


### PR DESCRIPTION
I fixed some issues with the bootstrap3 styles:
- bootstrap3 input transition
- support for .has-success, .has-warning and .has-error
- add right padding on .has-feedback
- fix height difference between input and selectize

See http://plnkr.co/edit/rci0eIvARvY3nEMQ40uq?p=preview

Tested in:
- Chrome 36
- Firefox 31
- Internet Explorer 10
- Internet Explorer 9
