### PR TITLE
Add option for readonly selectizes

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,6 +134,12 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>readonly</code></td>
+		<td valign="top">If true, user input will be disabled.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>false</code></td>
+	</tr>
+	<tr>
 		<th valign="top" colspan="4" align="left"><a href="#data_searching" name="data_searching">Data / Searching</a></th>
 	</tr>
 	<tr>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -16,6 +16,7 @@ Selectize.defaults = {
 	selectOnTab: false,
 	preload: false,
 	allowEmptyOption: false,
+	readonly: false,
 
 	scrollDuration: 60,
 	loadThrottle: 300,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -153,6 +153,10 @@ $.extend(Selectize.prototype, {
 			$control_input.attr('autocapitalize', $input.attr('autocapitalize'));
 		}
 
+    if (settings.readonly) {
+      $control_input.attr('readonly', settings.readonly);
+    }
+
 		self.$wrapper          = $wrapper;
 		self.$control          = $control;
 		self.$control_input    = $control_input;


### PR DESCRIPTION
Sometimes you just want a consistently skinned <select> replacement. Helps when you don't want the keyboard popping up on mobile devices, too.
