### PR TITLE
Fix @selectize-arrow-offset syntax for Bootstrap 3

### DIFF
--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -57,7 +57,7 @@
 
 @selectize-arrow-size: 5px;
 @selectize-arrow-color: @selectize-color-text;
-@selectize-arrow-offset: @selectize-padding-x + 5px;
+@selectize-arrow-offset: (@selectize-padding-x + 5px);
 
 .selectize-dropdown, .selectize-dropdown.form-control {
 	height: auto;


### PR DESCRIPTION
Fixes #574
