### PR TITLE
Ensure correct IE focus when the user clicks outside the focused control. #406

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -196,6 +196,7 @@ $.extend(Selectize.prototype, {
 				// blur on click outside
 				if (!self.$control.has(e.target).length && e.target !== self.$control[0]) {
 					self.blur();
+					e.target.focus();
 				}
 			}
 		});


### PR DESCRIPTION
Clicking on another input element when selectize has focus causes it to focus on the body in IE. By calling focus on the target after blurring, the focus event is fired as expected on IE.
