### PR TITLE
Added LESS file for Free Bootswatch's Flatly theme.

### DIFF
--- a/src/less/selectize.bootswatch.flatly.less
+++ b/src/less/selectize.bootswatch.flatly.less
@@ -1,0 +1,158 @@
+/**
+ * selectize.bootstrap3.css (v0.11.2) - Bootstrap 3 Theme adapted for Bootswatch Flatly
+ * Copyright (c) 2013 Brian Reavis & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * @author Brian Reavis <brian@thirdroute.com>
+ */
+
+@import "selectize";
+
+@selectize-font-family: @font-family-base;
+@selectize-font-size: @font-size-base;
+@selectize-line-height: @line-height-computed;
+
+@selectize-color-text: @text-color;
+@selectize-color-highlight: rgba(255,237,40,0.4);
+@selectize-color-input: @input-bg;
+@selectize-color-input-full: @input-bg;
+@selectize-color-input-error: @state-danger-text;
+@selectize-color-input-error-focus: darken(@selectize-color-input-error, 10%);
+@selectize-color-disabled: @input-bg;
+@selectize-color-item: #efefef;
+@selectize-color-item-border: rgba(0,0,0,0);
+@selectize-color-item-active: @component-active-bg;
+@selectize-color-item-active-text: #fff;
+@selectize-color-item-active-border: rgba(0,0,0,0);
+@selectize-color-optgroup: @dropdown-bg;
+@selectize-color-optgroup-text: @dropdown-header-color;
+@selectize-color-optgroup-border: @dropdown-divider-bg;
+@selectize-color-dropdown: @dropdown-bg;
+@selectize-color-dropdown-border-top: mix(@input-border, @input-bg, 0.8);
+@selectize-color-dropdown-item-active: @dropdown-link-hover-bg;
+@selectize-color-dropdown-item-active-text: @dropdown-link-hover-color;
+@selectize-color-dropdown-item-create-active-text: @dropdown-link-hover-color;
+@selectize-opacity-disabled: 0.5;
+@selectize-shadow-input: none;
+@selectize-shadow-input-focus: inset 0 1px 2px rgba(0,0,0,0.15);
+@selectize-shadow-input-error: inset 0 1px 1px rgba(0, 0, 0, .075);
+@selectize-shadow-input-error-focus: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px lighten(@selectize-color-input-error, 20%);
+@selectize-border: 2px solid @input-border; // bootswatch.less -> .form-control
+@selectize-border-radius: @input-border-radius;
+
+@selectize-width-item-border: 0;
+@selectize-padding-x: @padding-base-horizontal;
+@selectize-padding-y: @padding-base-vertical;
+@selectize-padding-dropdown-item-x: @padding-base-horizontal;
+@selectize-padding-dropdown-item-y: 3px;
+@selectize-padding-item-x: 3px;
+@selectize-padding-item-y: 1px;
+@selectize-margin-item-x: 3px;
+@selectize-margin-item-y: 3px;
+@selectize-caret-margin: 0;
+
+@selectize-arrow-size: 5px;
+@selectize-arrow-color: @selectize-color-text;
+@selectize-arrow-offset: @selectize-padding-x + 5px;
+
+.selectize-dropdown, .selectize-dropdown.form-control {
+	height: auto;
+	padding: 0;
+	margin: 2px 0 0 0;
+	z-index: @zindex-dropdown;
+	background: @selectize-color-dropdown;
+	border: 1px solid @dropdown-fallback-border;
+	border: 1px solid @dropdown-border;
+	.selectize-border-radius(@border-radius-base);
+	.selectize-box-shadow(0 6px 12px rgba(0,0,0,.175));
+
+	// better looking for flatly theme
+	& .active {
+		color: @selectize-color-text;
+		background: darken(@selectize-color-dropdown, 10%);
+	}
+}
+
+.selectize-dropdown {
+	.optgroup-header {
+		font-size: @font-size-small;
+		line-height: @line-height-base;
+	}
+	.optgroup:first-child:before {
+		display: none;
+	}
+	.optgroup:before {
+		content: ' ';
+		display: block;
+		.nav-divider();
+		margin-left: @selectize-padding-dropdown-item-x * -1;
+		margin-right: @selectize-padding-dropdown-item-x * -1;
+	}
+}
+
+.selectize-dropdown-content {
+	padding: 5px 0;
+}
+
+.selectize-dropdown-header {
+	padding: @selectize-padding-dropdown-item-y * 2 @selectize-padding-dropdown-item-x;
+}
+
+.selectize-input {
+	min-height: @input-height-base;
+
+	.transition(~"border-color ease-in-out .15s, box-shadow ease-in-out .15s"); // bootstrap/forms.less -> .form-control
+
+	&.dropdown-active {
+		.selectize-border-radius(@selectize-border-radius);
+	}
+	&.dropdown-active::before {
+		display: none;
+	}
+	&.focus {
+		@color: @input-border-focus;
+		@color-rgba: rgba(red(@color), green(@color), blue(@color), .6);
+		border-color: @color;
+		outline: 0;
+		.selectize-box-shadow(none); // bootswatch.less -> .form-control
+	}
+}
+
+.has-error .selectize-input {
+    border-color: @selectize-color-input-error;
+    .selectize-box-shadow(@selectize-shadow-input-error);
+
+    &:focus {
+        border-color: @selectize-color-input-error-focus;
+        .selectize-box-shadow(@selectize-shadow-input-error-focus);
+    }
+}
+
+.selectize-control {
+	&.multi {
+		.selectize-input.has-items {
+			padding-left: @selectize-padding-x - @selectize-padding-item-x;
+			padding-right: @selectize-padding-x - @selectize-padding-item-x;
+		}
+		.selectize-input > div {
+			.selectize-border-radius(@selectize-border-radius - 1px);
+		}
+	}
+}
+
+.form-control.selectize-control {
+	padding: 0;
+	height: auto;
+	border: none;
+	background: none;
+	.selectize-box-shadow(none);
+	.selectize-border-radius(0);
+}


### PR DESCRIPTION
I don't know if you would like to maintain aditional LESS files for Bootswatch themes.
But I've tweaked the `selectize.bootstrap3.less` file a bit so it would look better using Flatly theme.
The lines I've edited are marked with comments.

Essentialy:
- `@selectize-border` changed to `2px`
- Added transition to `.selectize-input`
- Removed box-shadow of `.selectize-input .focus`
- Changed `.selectize-dropdown .active` a bit.
