### PR TITLE
Allow render functions in options to return DOM.

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1019,7 +1019,7 @@ $.extend(Selectize.prototype, {
 		html = document.createDocumentFragment();
 		for (i = 0, n = groups_order.length; i < n; i++) {
 			optgroup = groups_order[i];
-			if (self.optgroups.hasOwnProperty(optgroup) && groups[optgroup].children.length) {
+			if (self.optgroups.hasOwnProperty(optgroup) && groups[optgroup].childNodes.length) {
 				// render the optgroup header and options within it,
 				// then pass it to the wrapper template
 				html_children = document.createDocumentFragment();

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1008,31 +1008,34 @@ $.extend(Selectize.prototype, {
 					optgroup = '';
 				}
 				if (!groups.hasOwnProperty(optgroup)) {
-					groups[optgroup] = [];
+					groups[optgroup] = document.createDocumentFragment();
 					groups_order.push(optgroup);
 				}
-				groups[optgroup].push(option_html);
+				groups[optgroup].appendChild(option_html);
 			}
 		}
 
 		// render optgroup headers & join groups
-		html = [];
+		html = document.createDocumentFragment();
 		for (i = 0, n = groups_order.length; i < n; i++) {
 			optgroup = groups_order[i];
 			if (self.optgroups.hasOwnProperty(optgroup) && groups[optgroup].length) {
 				// render the optgroup header and options within it,
 				// then pass it to the wrapper template
-				html_children = self.render('optgroup_header', self.optgroups[optgroup]) || '';
-				html_children += groups[optgroup].join('');
-				html.push(self.render('optgroup', $.extend({}, self.optgroups[optgroup], {
-					html: html_children
+				html_children = document.createDocumentFragment();
+				html_children.appendChild(self.render('optgroup_header', self.optgroups[optgroup]));
+				html_children.appendChild(groups[optgroup]);
+
+				html.appendChild(self.render('optgroup', $.extend({}, self.optgroups[optgroup], {
+					html: domToString(html_children),
+					dom:  html_children
 				})));
 			} else {
-				html.push(groups[optgroup].join(''));
+				html.appendChild(groups[optgroup]);
 			}
 		}
 
-		$dropdown_content.html(html.join(''));
+		$dropdown_content.html(html);
 
 		// highlight matching terms inline
 		if (self.settings.highlight && results.query.length && results.tokens.length) {
@@ -1906,26 +1909,26 @@ $.extend(Selectize.prototype, {
 		}
 
 		// render markup
-		html = self.settings.render[templateName].apply(this, [data, escape_html]);
+		html = $(self.settings.render[templateName].apply(this, [data, escape_html]));
 
 		// add mandatory attributes
 		if (templateName === 'option' || templateName === 'option_create') {
-			html = html.replace(regex_tag, '<$1 data-selectable');
+			html.attr('data-selectable', '');
 		}
-		if (templateName === 'optgroup') {
+		else if (templateName === 'optgroup') {
 			id = data[self.settings.optgroupValueField] || '';
-			html = html.replace(regex_tag, '<$1 data-group="' + escape_replace(escape_html(id)) + '"');
+			html.attr('data-group', id);
 		}
 		if (templateName === 'option' || templateName === 'item') {
-			html = html.replace(regex_tag, '<$1 data-value="' + escape_replace(escape_html(value || '')) + '"');
+			html.attr('data-value', value || '');
 		}
 
 		// update cache
 		if (cache) {
-			self.renderCache[templateName][value] = html;
+			self.renderCache[templateName][value] = html[0];
 		}
 
-		return html;
+		return html[0];
 	},
 
 	/**

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1019,7 +1019,7 @@ $.extend(Selectize.prototype, {
 		html = document.createDocumentFragment();
 		for (i = 0, n = groups_order.length; i < n; i++) {
 			optgroup = groups_order[i];
-			if (self.optgroups.hasOwnProperty(optgroup) && groups[optgroup].length) {
+			if (self.optgroups.hasOwnProperty(optgroup) && groups[optgroup].children.length) {
 				// render the optgroup header and options within it,
 				// then pass it to the wrapper template
 				html_children = document.createDocumentFragment();

--- a/src/utils.js
+++ b/src/utils.js
@@ -346,7 +346,7 @@ var autoGrow = function($input) {
 var domToString = function(d) {
 	var tmp = document.createElement('div');
 
-	tmp.appendChild(d.cloneNode());
+	tmp.appendChild(d.cloneNode(true));
 
 	return tmp.innerHTML;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -346,7 +346,7 @@ var autoGrow = function($input) {
 var domToString = function(d) {
 	var tmp = document.createElement('div');
 
-	tmp.appendChild(d);
+	tmp.appendChild(d.cloneNode());
 
 	return tmp.innerHTML;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -342,3 +342,11 @@ var autoGrow = function($input) {
 	$input.on('keydown keyup update blur', update);
 	update();
 };
+
+var domToString = function(d) {
+	var tmp = document.createElement('div');
+
+	tmp.appendChild(d);
+
+	return tmp.innerHTML;
+};

--- a/test/setup.js
+++ b/test/setup.js
@@ -242,6 +242,63 @@
 			});
 		});
 
+		describe('<select> (custom string render)', function() {
+			var test;
+
+			beforeEach(function() {
+				test = setup_test('<select>' +
+					'<option value="">Select an option...</option>' +
+					'<option value="a">A</option>' +
+				'</select>', {
+					render: {
+						option: function(item, escape) {
+							return '<div class="option custom-option">' + escape(item.text) + '</div>'
+						}
+					}
+				});
+			});
+
+			it('should render the custom option element', function(done) {
+				test.selectize.focus();
+
+				window.setTimeout(function() {
+					expect(test.selectize.$dropdown.find('.custom-option').length).to.be.equal(1);
+					done();
+				}, 5);
+			});
+		});
+
+		describe('<select> (custom dom render)', function() {
+			var test;
+
+			beforeEach(function() {
+				test = setup_test('<select>' +
+					'<option value="">Select an option...</option>' +
+					'<option value="a">A</option>' +
+				'</select>', {
+					render: {
+						option: function(item, escape) {
+							var div = document.createElement('div');
+
+							div.className = 'option custom-option';
+							div.innerHTML = escape(item.text);
+
+							return div;
+						}
+					}
+				});
+			});
+
+			it('should render the custom option element', function(done) {
+				test.selectize.focus();
+
+				window.setTimeout(function() {
+					expect(test.selectize.$dropdown_content.find('.custom-option').length).to.be.equal(1);
+					done();
+				}, 0);
+			});
+		});
+
 	});
 
 })();


### PR DESCRIPTION
This PR allows the functions in the render options "option", "item", "option_create", "optgroup_header", "optgroup" to return DOM nodes instead of plain strings.

This should come in handy, in contexts where we do not have strings but DOM, like in ember.js.

See:
https://github.com/miguelcobain/ember-selectize/blob/master/src/ember.selectize.js#L476
which caused
https://github.com/emberjs/ember.js/issues/5534

I have no idea what I'm going to break with these changes :)
