### PR TITLE
Prevent IE8 closing the dropdown when the selected option clicked

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -1027,8 +1027,9 @@
 			if (self.ignoreFocus) return;
 	
 			// necessary to prevent IE closing the dropdown when the scrollbar is clicked
-			if (!self.ignoreBlur && document.activeElement === self.$dropdown_content[0]) {
-				self.ignoreBlur = true;
+      // necessary to prevent IE8 closing the dropdown when the selected option clicked
+			if (!self.ignoreBlur && ((document.activeElement === self.$dropdown_content[0])) || ($(document.activeElement).parents('.selectize-dropdown-content')[0] == self.$dropdown_content[0])) {
+      	self.ignoreBlur = true;
 				self.onFocus(e);
 	
 				return;


### PR DESCRIPTION
Reproduce it:
1) Add "hideSelected: false" option to dynamic.html example file
2) Run dynamic.html in IE8
3) Select some option
4) Click to already selected option in dropdown
Current result: dropdown closed
Expected result: nothing do
