### PR TITLE
Allow jumping to next field with Tab if control is full

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -468,7 +468,12 @@ $.extend(Selectize.prototype, {
 			case KEY_TAB:
 				if (self.settings.selectOnTab && self.isOpen && self.$activeOption) {
 					self.onOptionSelect({currentTarget: self.$activeOption});
-					e.preventDefault();
+
+					// Default behaviour is to jump to the next field, we only want this
+					// if the current field doesn't accept any more entries
+					if (!self.isFull()) {
+						e.preventDefault();
+					}
 				}
 				if (self.settings.create && self.createItem()) {
 					e.preventDefault();


### PR DESCRIPTION
This fixes the behaviour introduced by https://github.com/brianreavis/selectize.js/pull/352
Synthesizing keyboard events is really tricky so I didn't bother writing tests for this.

Other related issues:
- https://github.com/brianreavis/selectize.js/issues/152
- https://github.com/brianreavis/selectize.js/issues/350
- https://github.com/brianreavis/selectize.js/issues/396
