### PR TITLE
Remove rendercache when removing all options

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1221,6 +1221,7 @@ $.extend(Selectize.prototype, {
 		self.lastQuery = null;
 		self.trigger('option_clear');
 		self.clear();
+		self.renderCache = {};
 	},
 
 	/**


### PR DESCRIPTION
Regarding this https://github.com/brianreavis/selectize.js/issues/317
