### PR TITLE
Usage.md correction

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,7 @@ $(function() {
 	<tr>
 		<td valign="top"><code>create</code></td>
 		<td valign="top">
-			Allows the user to create a new items that aren't in the list of options. This option can be any of the following: "true", "false" (disabled), or a function that accepts two arguments: "input" and "callback". The callback should be invoked with the final data for the option.</td>
+			Allows the user to create a new items that aren't in the list of options. This option can be any of the following: "true", "false" (disabled), or a function to process input. This function should take a single argument consisting of the search text and return an object in the same format as your list. For example: <code>create: function(input) { return { 'id': 0, 'name': input.toUppercase() } }</code> would create the option with all uppercase letters.</td>
 		<td valign="top"><code>mixed</code></td>
 		<td valign="top"><code>false</code></td>
 	</tr>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,7 @@ $(function() {
 	<tr>
 		<td valign="top"><code>create</code></td>
 		<td valign="top">
-			Allows the user to create a new items that aren't in the list of options. This option can be any of the following: "true", "false" (disabled), or a function to process input. This function should take a single argument consisting of the search text and return an object in the same format as your list. For example: <code>create: function(input) { return { 'id': 0, 'name': input.toUppercase() } }</code> would create the option with all uppercase letters.</td>
+			Allows the user to create a new items that aren't in the list of options. This option can be any of the following: "true", "false" (disabled), or a function to process input. The function can take one of two forms: synchronous (with signature <code>function(input){}</code> or asynchronous (with signature <code>function(input, callback)</code>. In the synchronous case, the function should <code>return</code> an object for the options (eg, with defaults: <code>return { 'value': value, 'text': text };</code>). The asynchronous version should invoke the callback with the result in the same format as the object above (eg, <code>callback( { 'value': value, 'text': text});</code>)</td>
 		<td valign="top"><code>mixed</code></td>
 		<td valign="top"><code>false</code></td>
 	</tr>


### PR DESCRIPTION
I attempted to use selectize.js with a `create: function(input, callback) {}` pattern, as suggested by the docs. This wouldn't work, as the function never returns anything.. After some light debugging, I realized that the `callback` function wasn't being used or defined. I tried setting up the function given in the example, and it worked. I checked some of the examples with this definition, and they all followed the given format.
