### PR TITLE
Configurable `loading` class name

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -110,6 +110,12 @@ $(function() {
 		<td valign="top"><code>300</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>loadingClass</code></td>
+		<td valign="top">The class name added to the wrapper element while awaiting the fulfillment of load requests.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>'loading'</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>preload</code></td>
 		<td valign="top">If true, the "load" function will be called upon control initialization (with an empty search). Alternatively it can be set to "focus" to call the "load" function when control receives focus.</td>
 		<td valign="top"><code>boolean/string</code></td>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -19,6 +19,7 @@ Selectize.defaults = {
 
 	scrollDuration: 60,
 	loadThrottle: 300,
+	loadingClass: 'loading',
 
 	dataAttr: 'data-data',
 	optgroupField: 'optgroup',

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -652,7 +652,7 @@ $.extend(Selectize.prototype, {
 	 */
 	load: function(fn) {
 		var self = this;
-		var $wrapper = self.$wrapper.addClass('loading');
+		var $wrapper = self.$wrapper.addClass(self.settings.loadingClass);
 
 		self.loading++;
 		fn.apply(self, [function(results) {
@@ -662,7 +662,7 @@ $.extend(Selectize.prototype, {
 				self.refreshOptions(self.isFocused && !self.isInputHidden);
 			}
 			if (!self.loading) {
-				$wrapper.removeClass('loading');
+				$wrapper.removeClass(self.settings.loadingClass);
 			}
 			self.trigger('load', results);
 		}]);


### PR DESCRIPTION
The `$wrapper` element is given a `'loading'` class name while asynchronous load requests are outstanding.

This pull request provides a configuration point for overriding the default value of `'loading'` during this operation.
