### PR TITLE
restore_on_focus plugin

### DIFF
--- a/src/plugins/restore_on_focus/plugin.js
+++ b/src/plugins/restore_on_focus/plugin.js
@@ -1,0 +1,36 @@
+/**
+ * Plugin: "restore_on_focus" (selectize.js)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ */
+
+Selectize.define('restore_on_focus', function(options) {
+  var self = this;
+
+  options.text = options.text || function(option) {
+    return option[this.settings.labelField];
+  };
+
+  var original = self.onFocus;
+  this.onFocus = (function(e) {
+    return function (e) {
+      var index = this.caretPos - 1;
+      if (index >= 0 && index < this.items.length) {
+        var option = this.options[this.items[index]];
+        var value = options.text.call(this, option);
+        this.removeItem(option[this.settings.valueField]);
+        this.setTextboxValue(value);
+        this.refreshOptions(true);
+      }
+      return original.apply(this, arguments);
+    }
+  })();
+});


### PR DESCRIPTION
Plugin to allow selectize controls to act more like traditional text inputs by restoring the text value on focus.
