### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
 	},
 	"main": [
 		"dist/css/selectize.css",
-		"dist/js/selectize.js"
+		"dist/js/standalone/selectize.js"
 	],
 	"ignore": [
 		"Makefile",


### PR DESCRIPTION
It would be nice if the bower file could point to the standalone selectize.

I think it is more common that people want selectize and are not using 'microplugin' and 'sifter' already.
