### PR TITLE
Delete control direction

### DIFF
--- a/src/plugins/restore_on_backspace/plugin.js
+++ b/src/plugins/restore_on_backspace/plugin.js
@@ -29,7 +29,7 @@ Selectize.define('restore_on_backspace', function(options) {
 				index = this.caretPos - 1;
 				if (index >= 0 && index < this.items.length) {
 					option = this.options[this.items[index]];
-					if (this.deleteSelection(e)) {
+					if (this.deleteSelection(e, true)) {
 						this.setTextboxValue(options.text.apply(this, [option]));
 						this.refreshOptions(true);
 					}

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -513,6 +513,8 @@ $.extend(Selectize.prototype, {
 				}
 				return;
 			case KEY_BACKSPACE:
+				self.deleteSelection(e, true);
+				return;
 			case KEY_DELETE:
 				self.deleteSelection(e);
 				return;
@@ -1775,16 +1777,19 @@ $.extend(Selectize.prototype, {
 	},
 
 	/**
-	 * Removes the current selected item(s).
+	 * Removes the current selected item(s),
+	 * optionally moving the caret position.
 	 *
 	 * @param {object} e (optional)
+	 * @param {boolean} back (optional)
 	 * @returns {boolean}
 	 */
-	deleteSelection: function(e) {
+	deleteSelection: function(e, back) {
 		var i, n, direction, selection, values, caret, option_select, $option_select, $tail;
 		var self = this;
 
-		direction = (e && e.keyCode === KEY_BACKSPACE) ? -1 : 1;
+		direction = back || (back === undefined && e && e.keyCode === KEY_BACKSPACE) ? -1 : 1;
+
 		selection = getSelection(self.$control_input[0]);
 
 		if (self.$activeOption && !self.settings.hideSelected) {


### PR DESCRIPTION
Deduplicate keycode inspection and make delete direction an explicit parameter to `deleteSelection`.

In order to make this a non-breaking change for plugin authors, the legacy, keycode-sniffing behavior is preserved when no `back` argument is used.
