### PR TITLE
Use @input-height-base instead of auto

### DIFF
--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -142,7 +142,7 @@
 
 .form-control.selectize-control {
 	padding: 0;
-	height: auto;
+	height: @input-height-base;
 	border: none;
 	background: none;
 	.selectize-box-shadow(none);


### PR DESCRIPTION
.form.control.selectize-control should use @input-height-base, like other form fields do.
