### PR TITLE
Add createPosition option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,6 +56,13 @@ $(function() {
 		<td valign="top"><code>null</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>createPosition</code></td>
+		<td valign="top">
+			Control the position of the create item option in the dropdown list. This option can be "first" (default) to appear at the top of the dropdown list, or "last" to appear at the bottom of the dropdown list.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>'first'</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>highlight</code></td>
 		<td valign="top">Toggles match highlighting within the dropdown menu.</td>
 		<td valign="top"><code>boolean</code></td>
@@ -211,7 +218,7 @@ $(function() {
 
 			Unless present, a special "$score" field will be automatically added to the beginning
 			of the sort list. This will make results sorted primarily by match quality (descending).<br><br>
-			
+
 
 			You can override the "$score" function. For more information, see the <a href="https://github.com/brianreavis/sifter.js#sifterjs">sifter documentation</a>.
 		</td>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -11,6 +11,7 @@ Selectize.defaults = {
 	create: false,
 	createOnBlur: false,
 	createFilter: null,
+	createPosition: 'first',
 	highlight: true,
 	openOnFocus: true,
 	maxOptions: 1000,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1112,8 +1112,14 @@ $.extend(Selectize.prototype, {
 		// add create option
 		has_create_option = self.canCreate(query);
 		if (has_create_option) {
-			$dropdown_content.prepend(self.render('option_create', {input: query}));
-			$create = $($dropdown_content[0].childNodes[0]);
+			var create_position = self.settings.createPosition;
+			if (create_position === 'last') {
+				$dropdown_content.append(self.render('option_create', {input: query}));
+				$create = $($dropdown_content[0].childNodes[$dropdown_content[0].childNodes.length - 1]);
+			} else {
+				$dropdown_content.prepend(self.render('option_create', {input: query}));
+				$create = $($dropdown_content[0].childNodes[0]);
+			}
 		}
 
 		// activate


### PR DESCRIPTION
According to the [documentation](https://github.com/brianreavis/selectize.js/blob/master/docs/usage.md#rendering), the "create new" option should appear last.

> The "create new" option at the bottom of the dropdown.

This PR adds a new configuration option to control placement, with options `first` (default) and `last`. This should ensure that Selectize does not change the positioning unexpectedly for existing users.

Built locally and [all tests pass](http://cl.ly/image/060L1l2r2v0p).
