### PR TITLE
Fixed scoping issue which prevented multiple instances from having similar options

### DIFF
--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -8,8 +8,6 @@ $.fn.selectize = function(settings_user) {
 	var field_optgroup_label = settings.optgroupLabelField;
 	var field_optgroup_value = settings.optgroupValueField;
 
-	var optionsMap = {};
-
 	/**
 	 * Initializes selectize from a <input type="text"> element.
 	 *
@@ -49,6 +47,7 @@ $.fn.selectize = function(settings_user) {
 	var init_select = function($input, settings_element) {
 		var i, n, tagName, $children, order = 0;
 		var options = settings_element.options;
+		var optionsMap = {};
 
 		var readData = function($el) {
 			var data = attr_data && $el.attr(attr_data);


### PR DESCRIPTION
If there are multiple instances of selectize on a page and each instance shares an option with the same value upon initialization, only the first instance will have their option pre-populated. This fix changes the scope of the optionsMap so that values are not shared between selectize instances.
