### PR TITLE
Added searchOnKeypress setting, fixed Firefox and IE tabbing behavior

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -570,7 +570,7 @@
 			$control_input    = $('<input type="text" autocomplete="off" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 			$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 			$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
-			$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);
+			$dropdown_content = $('<div tabindex="-1">').addClass(settings.dropdownContentClass).appendTo($dropdown);
 	
 			if(self.settings.copyClassesToDropdown) {
 				$dropdown.addClass(classes);
@@ -887,6 +887,7 @@
 		 */
 		onKeyDown: function(e) {
 			var isInput = e.target === this.$control_input[0];
+			var printable = (e.keyCode >= 32 && e.keyCode <= 126);
 			var self = this;
 	
 			if (self.isLocked) {
@@ -965,7 +966,7 @@
 			}
 	
 			if ((self.isFull() || self.isInputHidden) && !(IS_MAC ? e.metaKey : e.ctrlKey)) {
-				e.preventDefault();
+				self.settings.mode === 'single' && self.settings.searchOnKeypress && printable ? self.clear() : e.preventDefault();
 				return;
 			}
 		},
@@ -1067,8 +1068,9 @@
 				self.setCaret(self.items.length);
 				self.refreshState();
 	
-				// IE11 bug: element still marked as active
-				(dest || document.body).focus();
+				if (dest) {
+					dest.focus();
+				}
 	
 				self.ignoreFocus = false;
 				self.trigger('blur');
@@ -2571,6 +2573,7 @@
 		preload: false,
 		allowEmptyOption: false,
 		closeAfterSelect: false,
+		searchOnKeypress: true,
 	
 		scrollDuration: 60,
 		loadThrottle: 300,


### PR DESCRIPTION
Should fix #396 (there are actually 2 distinct issues in there - the original Firefox issue, and an IE tabbing issue), and provides a way to start searching when the user types, ala #477 but with a setting to turn it off.
