### PR TITLE
Added searchOnKeypress setting, fixed Firefox and IE tabbing behavior

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -21,6 +21,7 @@ Selectize.defaults = {
 	preload: false,
 	allowEmptyOption: false,
 	closeAfterSelect: false,
+	searchOnKeypress: true,
 
 	scrollDuration: 60,
 	loadThrottle: 300,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -124,7 +124,7 @@ $.extend(Selectize.prototype, {
 		$control_input    = $('<input type="text" autocomplete="off" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 		$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 		$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
-		$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);
+		$dropdown_content = $('<div tabindex="-1">').addClass(settings.dropdownContentClass).appendTo($dropdown);
 
 		if(self.settings.copyClassesToDropdown) {
 			$dropdown.addClass(classes);
@@ -441,6 +441,7 @@ $.extend(Selectize.prototype, {
 	 */
 	onKeyDown: function(e) {
 		var isInput = e.target === this.$control_input[0];
+		var printable = (e.keyCode >= 32 && e.keyCode <= 126);
 		var self = this;
 
 		if (self.isLocked) {
@@ -519,7 +520,7 @@ $.extend(Selectize.prototype, {
 		}
 
 		if ((self.isFull() || self.isInputHidden) && !(IS_MAC ? e.metaKey : e.ctrlKey)) {
-			e.preventDefault();
+			self.settings.mode === 'single' && self.settings.searchOnKeypress && printable ? self.clear() : e.preventDefault();
 			return;
 		}
 	},
@@ -621,8 +622,9 @@ $.extend(Selectize.prototype, {
 			self.setCaret(self.items.length);
 			self.refreshState();
 
-			// IE11 bug: element still marked as active
-			(dest || document.body).focus();
+			if (dest) {
+				dest.focus();
+			}
 
 			self.ignoreFocus = false;
 			self.trigger('blur');


### PR DESCRIPTION
Should fix #396 (there are actually 2 distinct issues in there - the original Firefox issue, and an IE tabbing issue), and provides a way to start searching when the user types, ala #477 but with a setting to turn it off.
