### PR TITLE
Simplify API calls for jQuery elements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,19 @@ var $select = $('select').selectize(options);
 var selectize = $select[0].selectize;
 ```
 
+Or, you can pass an API method you want to call as an argument,
+along with any arguments:
+
+```js
+// initialize the selectize control
+var $select = $('select').selectize(options);
+
+// call an API method
+$select.selectize('getValue'); //=> "1"
+$select.selectize('setValue', 4);
+$select.selectize('getValue'); //=> "4"
+```
+
 #### Related Topics
 
 - [Event Documentation](events.md)

--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -1,6 +1,14 @@
-$.fn.selectize = function(settings_user) {
+$.fn.selectize = function(options) {
+	if(typeof options === 'string'){
+		var el = this[0];
+		if (el && el.selectize){
+			var instance = el.selectize;
+			var args = Array.prototype.slice.call(arguments, 1);
+			return instance[options].apply(instance, args);
+		} else return;
+	}
 	var defaults             = $.fn.selectize.defaults;
-	var settings             = $.extend({}, defaults, settings_user);
+	var settings             = $.extend({}, defaults, options);
 	var attr_data            = settings.dataAttr;
 	var field_label          = settings.labelField;
 	var field_value          = settings.valueField;
@@ -150,7 +158,7 @@ $.fn.selectize = function(settings_user) {
 			init_textbox($input, settings_element);
 		}
 
-		instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, settings_user));
+		instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, options));
 	});
 };
 


### PR DESCRIPTION
Previously, when user wanted to call any API method, he had to do it that way:

``` js
var $select = $('select').selectize(options);
var selectize = $select[0].selectize;
selectize.getValue()
// One-liner:
$('select')[0].selectize.getValue()
```

IMHO that doesn't look good. So I've added another way of API method invocation, which is a bit more jQuery-like and follows the same pattern as what Select2 follows. Samples of what it looks like:

``` js
$('select').selectize('setValue', 5)
$('select').selectize('getValue') //=> "5"
$('select').selectize('disable')
```

It is backwards compatible, the only change was done is that we're checking for type of an option passed to `$.selectize`, and if it's type is a `string`, we invoke responding API method on `selectize` attribute. If not - regular behavior takes place.
