### PR TITLE
Settings for optgroup are not used

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -2728,14 +2728,15 @@
 			};
 	
 			var addGroup = function($optgroup) {
-				var i, n, id, optgroup, $options;
+				var i, n, id, label, optgroup, $options;
 	
 				$optgroup = $($optgroup);
-				id = $optgroup.attr('label');
+				id = $optgroup.attr(settings.optgroupValueField);
+				label = $optgroup.attr(settings.optgroupLabelField);
 	
 				if (id) {
 					optgroup = readData($optgroup) || {};
-					optgroup[field_optgroup_label] = id;
+					optgroup[field_optgroup_label] = label;
 					optgroup[field_optgroup_value] = id;
 					settings_element.optgroups.push(optgroup);
 				}

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -3337,14 +3337,15 @@
 			};
 	
 			var addGroup = function($optgroup) {
-				var i, n, id, optgroup, $options;
+				var i, n, id, label, optgroup, $options;
 	
 				$optgroup = $($optgroup);
-				id = $optgroup.attr('label');
+				id = $optgroup.attr(settings.optgroupValueField);
+				label = $optgroup.attr(settings.optgroupLabelField);
 	
 				if (id) {
 					optgroup = readData($optgroup) || {};
-					optgroup[field_optgroup_label] = id;
+					optgroup[field_optgroup_label] = label;
 					optgroup[field_optgroup_value] = id;
 					settings_element.optgroups.push(optgroup);
 				}


### PR DESCRIPTION
Hi,
Quite a big bug : none of the settings used for adding optgroups are used. The id and the label are the same...

Regards,
