### PR TITLE
Make label[for] work with selectized input

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -106,6 +106,7 @@ $.extend(Selectize.prototype, {
 		var tab_index;
 		var classes;
 		var classes_plugins;
+		var inputId;
 
 		inputMode         = self.settings.mode;
 		tab_index         = $input.attr('tabindex') || '';
@@ -117,6 +118,11 @@ $.extend(Selectize.prototype, {
 		$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 		$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
 		$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);
+
+		if(inputId = $input.attr('id')) {
+			$control_input.attr('id', inputId + '_selectized');
+			$('label[for='+inputId+']').attr('for', inputId + '_selectized');
+		}
 
 		if(self.settings.copyClassesToDropdown) {
 			$dropdown.addClass(classes);

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -45,7 +45,7 @@
 
 			it('should give it focus to select', function(done) {
 				var inputId = "labeledSelect";
-		        $('#fixture').append('<label for="'+inputId+'">select</label>');
+				$('#fixture').append('<label for="'+inputId+'">select</label>');
 				var label = $('label[for="'+inputId+'"]');
 
 				var test = setup_test('<select id="'+inputId+'">' +
@@ -64,7 +64,7 @@
 
 			it('should give it focus to input', function(done) {
 				var inputId = "labeledInput";
-		        $('#fixture').append('<label for="'+inputId+'">input</label>');
+				$('#fixture').append('<label for="'+inputId+'">input</label>');
 				var label = $('label[for="'+inputId+'"]');
 				
 				var test = setup_test('<input id="'+inputId+'" type="text" value="a,b,c,d">', {});
@@ -276,7 +276,7 @@
 				expect(selectize.getItem(text).length).to.be.equal(0);
 				expect($(selectize.$dropdown_content).filter('.create').length).to.be.equal(0);
 			});
- 		});
+		});
 
 	});
 

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -41,6 +41,45 @@
 
 		});
 
+		describe('clicking label', function() {
+
+			it('should give it focus to select', function(done) {
+				var inputId = "labeledSelect";
+		        $('#fixture').append('<label for="'+inputId+'">select</label>');
+				var label = $('label[for="'+inputId+'"]');
+
+				var test = setup_test('<select id="'+inputId+'">' +
+					'<option value="a">A</option>' +
+					'<option value="b">B</option>' +
+				'</select>', {});
+
+				Syn
+					.click(label)
+					.delay(0, function() {
+						label.remove();
+						expect(test.selectize.isFocused).to.be.equal(true);
+						done();
+					});
+			});
+
+			it('should give it focus to input', function(done) {
+				var inputId = "labeledInput";
+		        $('#fixture').append('<label for="'+inputId+'">input</label>');
+				var label = $('label[for="'+inputId+'"]');
+				
+				var test = setup_test('<input id="'+inputId+'" type="text" value="a,b,c,d">', {});
+
+				Syn
+					.click(label)
+					.delay(0, function() {
+						label.remove();
+						expect(test.selectize.isFocused).to.be.equal(true);
+						done();
+					});
+			});
+
+		});
+
 		describe('clicking option', function() {
 
 			it('should select it', function(done) {


### PR DESCRIPTION
this updates any existing labels pointing to the original input or select to point to the selectize input/select #658

maintained id uniqueness by appending '_selectized' string
