### PR TITLE
Don't lose the dropdown's focus when the user clicks on an optgroup heading

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -204,7 +204,8 @@ $.extend(Selectize.prototype, {
 		$document.on('mousedown' + eventNS, function(e) {
 			if (self.isFocused) {
 				// prevent events on the dropdown scrollbar from causing the control to blur
-				if (e.target === self.$dropdown[0] || e.target.parentNode === self.$dropdown[0]) {
+				if (e.target === self.$dropdown[0] || e.target.parentNode === self.$dropdown[0] ||
+						$(e.target).hasClass('optgroup-header')) {
 					return false;
 				}
 				// blur on click outside


### PR DESCRIPTION
When you have lots of option groups in a list and a small number of options in each group, the user may accidentally click on an optgroup heading, which blurs focus from selectize and closes the dropdown. This seems to be unintentional behaviour given that clicking on any other empty area of the dropdown (not including options) will not cause focus to be lost.

This fix checks to see if the class name of the element being clicked on is that of an optgroup heading and if so, prevents focus from being lost.
