### PR TITLE
2 new settings

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -71,8 +71,7 @@ var Selectize = function($input, settings) {
 	}
 
 	//if specified, do not make options active on mouse hover
-	if (self.settings.ignoreHover)
-	{
+	if (self.settings.ignoreHover) {
 		self.ignoreHover = true;
 	}
 
@@ -226,8 +225,7 @@ $.extend(Selectize.prototype, {
 			}
 		});
 		$window.on('mousemove' + eventNS, function() {
-			if (!self.settings.ignoreHover)
-			{
+			if (!self.settings.ignoreHover) {
 				self.ignoreHover = false;
 			}
 		});

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -76,11 +76,6 @@ var Selectize = function($input, settings) {
 		self.settings.hideSelected = self.settings.mode === 'multi';
 	}
 
-	//if specified, do not make options active on mouse hover
-	{
-		self.ignoreHover = true;
-	}
-
 	self.initializePlugins(self.settings.plugins);
 	self.setupCallbacks();
 	self.setupTemplates();
@@ -225,10 +220,7 @@ $.extend(Selectize.prototype, {
 			}
 		});
 		$window.on('mousemove' + eventNS, function() {
-			if (!self.settings.ignoreHover)
-			{
-				self.ignoreHover = false;
-			}
+			self.ignoreHover = false;
 		});
 
 		// store original children and tab index so that they can be

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -77,7 +77,6 @@ var Selectize = function($input, settings) {
 	}
 
 	//if specified, do not make options active on mouse hover
-	if (self.settings.ignoreHover)
 	{
 		self.ignoreHover = true;
 	}

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1130,7 +1130,9 @@ $.extend(Selectize.prototype, {
 		if (self.hasOptions) {
 			if (results.items.length > 0) {
 				$active_before = active_before && self.getOption(active_before);
-				if ($active_before && $active_before.length) {
+				if (self.settings.alwaysActivateFirstMatch) {
+					$active = self.getOption(self.items[0]);
+				} else if ($active_before && $active_before.length) {
 					$active = $active_before;
 				} else if (self.settings.mode === 'single' && self.items.length) {
 					$active = self.getOption(self.items[0]);

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -77,6 +77,7 @@ var Selectize = function($input, settings) {
 	}
 
 	//if specified, do not make options active on mouse hover
+	if (self.settings.ignoreHover)
 	{
 		self.ignoreHover = true;
 	}

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -70,6 +70,12 @@ var Selectize = function($input, settings) {
 		delete self.settings.optgroups;
 	}
 
+	//if specified, do not make options active on mouse hover
+	if (self.settings.ignoreHover)
+	{
+		self.ignoreHover = true;
+	}
+
 	// option-dependent defaults
 	self.settings.mode = self.settings.mode || (self.settings.maxItems === 1 ? 'single' : 'multi');
 	if (typeof self.settings.hideSelected !== 'boolean') {
@@ -220,7 +226,10 @@ $.extend(Selectize.prototype, {
 			}
 		});
 		$window.on('mousemove' + eventNS, function() {
-			self.ignoreHover = false;
+			if (!self.settings.ignoreHover)
+			{
+				self.ignoreHover = false;
+			}
 		});
 
 		// store original children and tab index so that they can be

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -76,6 +76,11 @@ var Selectize = function($input, settings) {
 		self.settings.hideSelected = self.settings.mode === 'multi';
 	}
 
+	//if specified, do not make options active on mouse hover
+	{
+		self.ignoreHover = true;
+	}
+
 	self.initializePlugins(self.settings.plugins);
 	self.setupCallbacks();
 	self.setupTemplates();
@@ -220,7 +225,10 @@ $.extend(Selectize.prototype, {
 			}
 		});
 		$window.on('mousemove' + eventNS, function() {
-			self.ignoreHover = false;
+			if (!self.settings.ignoreHover)
+			{
+				self.ignoreHover = false;
+			}
 		});
 
 		// store original children and tab index so that they can be


### PR DESCRIPTION
- Added setting:"ignoreHover"
  When true, this setting will prevent the automatic activation of hovered options.
- Added setting "alwaysActivateFirstMatch":
  When true, will always activate the first option in the dropdown list results

Those settings are useful to always get the same option selected when hitting Enter.

This is in response to issue #742.
