### PR TITLE
add revertChildrenOnDestroy setting

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -158,6 +158,12 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>revertChildrenOnDestroy</code></td>
+		<td valign="top">If true, when you call destroy method, all options will be reverted to previous state, selection will be reverted, and all AJAX-loaded options will be removed even if they are selected.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>true</code></td>
+	</tr>
+	<tr>
 		<th valign="top" colspan="4" align="left"><a href="#data_searching" name="data_searching">Data / Searching</a></th>
 	</tr>
 	<tr>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -21,6 +21,7 @@ Selectize.defaults = {
 	preload: false,
 	allowEmptyOption: false,
 	closeAfterSelect: false,
+	revertChildrenOnDestroy: true,
 
 	scrollDuration: 60,
 	loadThrottle: 300,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1995,9 +1995,12 @@ $.extend(Selectize.prototype, {
 		self.$wrapper.remove();
 		self.$dropdown.remove();
 
+		if (self.settings.revertChildrenOnDestroy) {
+			self.$input
+				.html('')
+				.append(revertSettings.$children)
+		}
 		self.$input
-			.html('')
-			.append(revertSettings.$children)
 			.removeAttr('tabindex')
 			.removeClass('selectized')
 			.attr({tabindex: revertSettings.tabindex})


### PR DESCRIPTION
Sometimes we need to keep options which were added while selectize was present at the element even after destroy.
In my case, I needed to destroy and re-create selectize input on subcategories each time user changes main category, but when I did so, my select was being completely reset to the state it had previously (even if I selected some subcategory which had to be persisted after selectize destroy and re-initialization).
**This PR adds a setting to keep select's options after Selectize's destroy method is called. The change is backwards-compatible, previous behavior is default.**

Here's an example:
### Previous behavior or default (true) revertChildrenOnDestroy setting:

Page load:

``` html
<select class="selectize">
  <option value="14" selected="selected">Painting</option>
</select>
```

Selectize initialized, some settings are fetched with AJAX:

``` html
<select class="selectize selectized" tabindex="-1" style="display: none;">
  <option value="14" selected="selected">Painting</option>
</select>
```

Value changed with Selectize:

``` html
<select class="selectize selectized" tabindex="-1" style="display: none;">
  <option value="16" selected="selected">Music</option>
</select>
```

Selectize destroyed:

``` html
<select class="selectize">
  <option value="14" selected="selected">Painting</option>
</select>
```

**As you can see, even if user changed his selection, it will be reset on Selectize destroy.**
### Updated behavior or revertChildrenOnDestroy setting is false:

Page load:

``` html
<select class="selectize">
  <option value="14" selected="selected">Painting</option>
</select>
```

Selectize initialized, some settings are fetched with AJAX:

``` html
<select class="selectize selectized" tabindex="-1" style="display: none;">
  <option value="14" selected="selected">Painting</option>
</select>
```

Value changed with Selectize:

``` html
<select class="selectize selectized" tabindex="-1" style="display: none;">
  <option value="16" selected="selected">Music</option>
</select>
```

Selectize destroyed:

``` html
<select class="selectize">
  <option value="16" selected="selected">Music</option>
</select>
```
