### PR TITLE
Support for chaining on functions .focus() and .blur()

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -915,7 +915,7 @@ $.extend(Selectize.prototype, {
 	 */
 	focus: function() {
 		var self = this;
-		if (self.isDisabled) return;
+		if (self.isDisabled) return self;
 
 		self.ignoreFocus = true;
 		self.$control_input[0].focus();
@@ -923,6 +923,7 @@ $.extend(Selectize.prototype, {
 			self.ignoreFocus = false;
 			self.onFocus();
 		}, 0);
+		return self;
 	},
 
 	/**
@@ -933,6 +934,7 @@ $.extend(Selectize.prototype, {
 	blur: function(dest) {
 		this.$control_input[0].blur();
 		this.onBlur(null, dest);
+		return this;
 	},
 
 	/**

--- a/test/api.js
+++ b/test/api.js
@@ -49,11 +49,11 @@
 		});
 
 		describe('focus()', function() {
-			var test;
+			var test, self;
 
 			before(function(done) {
 				test = setup_test('<select>', {});
-				test.selectize.focus();
+				self = test.selectize.focus();
 				window.setTimeout(function() { done(); }, 5);
 			});
 
@@ -63,16 +63,19 @@
 			it('should give the control focus', function() {
 				expect(has_focus(test.selectize.$control_input[0])).to.be.equal(true);
 			});
+			it('should return self to support chaining', function() {
+				expect(self.getValue()).to.be.equal('');
+			});
 		});
 
 		describe('blur()', function() {
-			var test;
+			var test, self;
 
 			before(function(done) {
 				test = setup_test('<select>', {});
 				test.selectize.focus();
 				window.setTimeout(function() {
-					test.selectize.blur();
+					self = test.selectize.blur();
 					window.setTimeout(done, 100);
 				}, 50);
 			});
@@ -81,6 +84,9 @@
 			});
 			it('should remove focus from the control', function() {
 				expect(has_focus(test.selectize.$control_input[0])).to.be.equal(false);
+			});
+			it('should return self to support chaining', function() {
+				expect(self.getValue()).to.be.equal('');
 			});
 		});
 


### PR DESCRIPTION
Allows convenient usage such as:
`var books = $('#books')[0].selectize.blur().getValue();`
