### PR TITLE
Plugin: sub_menu

### DIFF
--- a/examples/plugins.html
+++ b/examples/plugins.html
@@ -113,6 +113,34 @@
 				})
 				</script>
 			</div>
+      <div class="demo">
+        <h2>Plugin: "sub_menu"</h2>
+        <div class="control-group" style="width:210px">
+          <input id="sub-menu">
+        </div>
+        <script>
+          $('#sub-menu').selectize({
+              options: [
+                  {class: 'mammal', value: "dog", name: "Dog" },
+                  {class: 'mammal', value: "cat", name: "Cat" },
+                  {class: 'mammal', value: "horse", name: "Horse" },
+                  {class: 'mammal', value: "kangaroo", name: "Kangaroo" },
+                  {class: 'bird', value: 'duck', name: 'Duck'},
+                  {class: 'bird', value: 'chicken', name: 'Chicken'},
+                  {class: 'bird', value: 'ostrich', name: 'Ostrich'},
+                  {class: 'bird', value: 'seagull', name: 'Seagull'}
+              ],
+              optgroups: [
+                  {value: 'mammal', label: 'Mammal'},
+                  {value: 'bird', label: 'Bird'}
+              ],
+              optgroupField: 'class',
+              plugins: ['sub_menu'],
+              labelField: 'name',
+              searchField: ['name']
+          });
+        </script>
+      </div>
 		</div>
 	</body>
 </html>

--- a/src/plugins/sub_menu/plugin.js
+++ b/src/plugins/sub_menu/plugin.js
@@ -1,0 +1,104 @@
+/**
+ * Plugin: "sub_menu" (selectize.js)
+ * Copyright (c) 2013 Marius Edelsbrunner & contributors
+ *
+ * @author Marius Edelsbrunner <marius@solcomputadores.com.br>
+*/
+
+Selectize.define('sub_menu', function(options) {
+	if (this.settings.mode === 'single') return;
+
+	options = $.extend({
+		className : 'dropdown-hover',
+		append    : true
+	}, options);
+
+	var self = this;
+	/**
+	 * Overwrite render method to change optgroup structure, adding items inside of <nav>
+	 *
+	 * @param {string} templateName
+	 * @param {object} data
+	 * @return {string}
+	*/
+
+  this.render = (function(templateName, data) {
+    var value, id, label;
+    var html = '';
+    var cache = false;
+    var self = this;
+    var regex_tag = /^[\t \r\n]*<([a-z][a-z0-9\-_]*(?:\:[a-z][a-z0-9\-_]*)?)/i;
+    if (templateName === 'option' || templateName === 'item') {
+      value = hash_key(data[self.settings.valueField]);
+      cache = !!value;
+    }
+
+    // pull markup from cache if it exists
+    if (cache) {
+      if (!isset(self.renderCache[templateName])) {
+        self.renderCache[templateName] = {};
+      }
+      if (self.renderCache[templateName].hasOwnProperty(value)) {
+        return self.renderCache[templateName][value];
+      }
+    }
+
+    if (templateName == "optgroup"){
+      data.html = data.html.replace('</li></ul></li></ul></nav></div>', '');
+      data.html = data.html + "</li></ul></li></ul></nav></div>";
+    }
+
+    // render markup
+    html = self.settings.render[templateName].apply(this, [data, escape_html]);
+
+    // add mandatory attributes
+    if (templateName === 'option' || templateName === 'option_create') {
+      html = html.replace(regex_tag, '<$1 data-selectable');
+    }
+    if (templateName === 'optgroup') {
+      id = data[self.settings.optgroupValueField] || '';
+      html = html.replace(regex_tag, '<$1 data-group="' + escape_replace(escape_html(id)) + '"');
+    }
+    if (templateName === 'option' || templateName === 'item') {
+      html = html.replace(regex_tag, '<$1 data-value="' + escape_replace(escape_html(value || '')) + '"');
+    }
+
+    // update cache
+    if (cache) {
+      self.renderCache[templateName][value] = html;
+    }
+
+    return html;
+  });
+
+
+  /**
+   * Add categories with sub-menu element to the header
+   *
+  */
+	this.setup = (function() {
+		var original = self.setup;
+		return function() {
+			// override the optgroup rendering method to add the button to each
+			if (options.append) {
+				var render_item = self.settings.render.optgroup_header;
+				self.settings.render.optgroup_header = function(data) {
+					return '<div class="optgroup-header"><nav><ul><li class="' + options.className + '"><a href="#">' + escape(data.label) + '</a><ul class="sub-menu"><li class="dropdown" style="width:200px;"></li></ul></li></ul></nav></div>'
+				};
+			}
+
+			original.apply(this, arguments);
+
+    /**
+     * Mouse hover events to show/hide submenus
+     *
+    */
+      self.$dropdown.on('hover', '.' + 'optgroup-header', function(e) {
+        $(this).children('nav').children('ul').children('.dropdown-hover').children('.sub-menu').show();
+      })
+      self.$dropdown.on('mouseleave', '.' + 'optgroup-header', function(e) {
+        $(this).children('nav').children('ul').children('.dropdown-hover').children('.sub-menu').hide();
+      })
+  }})()
+
+});

--- a/src/plugins/sub_menu/plugin.less
+++ b/src/plugins/sub_menu/plugin.less
@@ -1,0 +1,97 @@
+nav {
+    padding:0px 0;
+    width:200px;
+    background-color:white;
+    position:absolute;
+}
+
+.optgroup-header {
+  height: 40px;
+}
+
+nav li .dropdown {
+    width:200px;
+}
+nav:hover {
+    background-color:#08c;
+}
+nav ul {
+    list-style-type:none;
+    margin:0;
+    padding:0;
+
+}
+nav ul li {
+    display:inline-block;
+    position:relative;
+}
+
+/* sub navigation */
+nav li ul {
+    background-color:#fff;
+    position:absolute;
+    left:200px;
+    top:0px; /* make this equal to the line-height of the links (specified below) */
+    width:200px;
+}
+nav li ul a:hover {
+    background-color:#08c;
+}
+nav li li {
+    position:relative;
+    margin:0;
+    display:block;
+}
+nav li li ul {
+    position:absolute;
+    top:0;
+    left:200px; /* make this equal to the width of the sub nav above */
+    margin:0;
+}
+
+/* style all links */
+nav a {
+    line-height:40px;
+    padding:0 12px;
+    margin:0 12px;
+}
+nav a {
+    color:black;
+    text-decoration:none;
+    display:block;
+}
+nav a:hover,
+nav a:focus,
+nav a:active {
+    color:#fff;
+}
+
+/* style sub level links */
+nav li li a {
+    border-bottom:solid 1px rgb(200,50,50);
+    margin:0 3px;
+    padding:0;
+    padding-left:8px;
+}
+nav li li:last-child a {
+    border-bottom:none;
+}
+
+/* show arrows for dropdowns */
+nav li.dropdown > a {
+    background-position:right 20px;
+    background-repeat:no-repeat;
+}
+
+nav li li.dropdown > a {
+    background-position:right 16px;
+    background-repeat:no-repeat;
+}
+
+ul.sub-menu {
+    display:none;
+}
+ul.sub-menu:hover {
+    display:block;
+}
+


### PR DESCRIPTION
Hi all,

I've created a sub_menu plugin. Just created inside of plugins the JS and LESS file.

And updated the plugins.html from examples/ folder.

It work together with the "optgroup", if you define plugins: ["sub_menu"], it will replace the optgroups by the Menu options.

![sub_menu](https://cloud.githubusercontent.com/assets/1163058/8077704/5fec60fa-0f58-11e5-87fa-1b9a73754f1f.png)
![sub_menu2](https://cloud.githubusercontent.com/assets/1163058/8077709/629779c0-0f58-11e5-887b-3592b6b4694b.png)

Best Regards,

Marius Edelsbrunner
