### PR TITLE
Add getOptions() method to return all current options

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1351,6 +1351,22 @@ $.extend(Selectize.prototype, {
 	},
 
 	/**
+	 * Returns an array of current options
+	 *
+	 * @returns {array}
+	 */
+	getOptions: function() {
+		var self = this;
+		var $options = [];
+
+		for (var key in self.options) {
+			$options.push(self.options[key])
+		}
+
+		return $options;
+	},
+
+	/**
 	 * Returns the jQuery element of the next or
 	 * previous selectable option.
 	 *

--- a/test/api.js
+++ b/test/api.js
@@ -437,6 +437,39 @@
 			});
 		});
 
+		describe('getOptions()', function() {
+			var test;
+
+			before(function() {
+				test = setup_test('<select>', {
+					valueField: 'value',
+					labelField: 'value',
+					options: [
+						{value: 0 },
+						{value: 1, text: 1},
+						{value: 'a', text: 'a'},
+						{value: 'b'},
+						{value: '\''},
+						{value: '\\'},
+						{value: '"'},
+						{value: '\\\''},
+						{value: '\\"'},
+						{value: ' ', text: ' '},
+					]
+				});
+				test.selectize.refreshOptions(true);
+			});
+			it('should return all values when options exisit', function() {
+				expect(test.selectize.getOptions()).to.be.ok;
+				expect(test.selectize.getOptions().length).to.be.equal(10);
+			});
+			it('should return empty when no options exisit', function() {
+				test.selectize.clearOptions();
+				expect(test.selectize.getOptions()).to.be.ok;
+				expect(test.selectize.getOptions().length).to.be.equal(0);
+			});
+		});
+
 		describe('getItem()', function() {
 			var test;
 

--- a/test/api.js
+++ b/test/api.js
@@ -459,11 +459,11 @@
 				});
 				test.selectize.refreshOptions(true);
 			});
-			it('should return all values when options exisit', function() {
+			it('should return all values when options exists', function() {
 				expect(test.selectize.getOptions()).to.be.ok;
 				expect(test.selectize.getOptions().length).to.be.equal(10);
 			});
-			it('should return empty when no options exisit', function() {
+			it('should return empty when no options exists', function() {
 				test.selectize.clearOptions();
 				expect(test.selectize.getOptions()).to.be.ok;
 				expect(test.selectize.getOptions().length).to.be.equal(0);


### PR DESCRIPTION
This adds a new API method getOptions() which returns an array of all current options in the selectize drop down. The array format is API compatible with the existing addOption() method. This makes it easy to clone an existing selectize input and would help with closed issue #145 and other requests I have seen.
