### PR TITLE
Add option to disable delete on backspace

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -158,6 +158,12 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>disableDelete</code></td>
+		<td valign="top">If true, the backspace key will not delete the previous selected item.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>false</code></td>
+	</tr>
+	<tr>
 		<th valign="top" colspan="4" align="left"><a href="#data_searching" name="data_searching">Data / Searching</a></th>
 	</tr>
 	<tr>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -46,6 +46,8 @@ Selectize.defaults = {
 
 	dropdownParent: null,
 
+	disableDelete: false,
+
 	copyClassesToDropdown: true,
 
 	/*

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1784,6 +1784,10 @@ $.extend(Selectize.prototype, {
 		var i, n, direction, selection, values, caret, option_select, $option_select, $tail;
 		var self = this;
 
+		if (self.settings.disableDelete && e && e.keyCode === KEY_BACKSPACE) {
+			return;
+		}
+
 		direction = (e && e.keyCode === KEY_BACKSPACE) ? -1 : 1;
 		selection = getSelection(self.$control_input[0]);
 


### PR DESCRIPTION
Setting disableDelete to true will prevent the user from deleting the previous item when backspace is pressed
