### PR TITLE
Configurable "Add" text translation

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -291,7 +291,7 @@ $.extend(Selectize.prototype, {
 				return '<div class="item">' + escape(data[field_label]) + '</div>';
 			},
 			'option_create': function(data, escape) {
-				return '<div class="create">Add <strong>' + escape(data.input) + '</strong>&hellip;</div>';
+				return '<div class="create">' + (self.settings.addText || 'Add') + ' <strong>' + escape(data.input) + '</strong>&hellip;</div>';
 			}
 		};
 


### PR DESCRIPTION
When create option is set to true, you can input a new item into a selectize field. However the option had a fixed text "Add" as prefix in the dropdown menu.

This pull request makes this text configurable.
