### PR TITLE
Implement removeItems() similar to addItems()

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1474,6 +1474,13 @@ $.extend(Selectize.prototype, {
 		});
 	},
 
+	removeItems: function(values, silent) {
+		var items = $.isArray(values) ? values : [values];
+		for (var i = 0, n = items.length; i < n; i++) {
+			this.isPending = (i < n - 1);
+			this.removeItem(items[i], silent);
+		}
+	},
 	/**
 	 * Removes the selected item matching
 	 * the provided value.
@@ -1505,7 +1512,10 @@ $.extend(Selectize.prototype, {
 				self.setCaret(self.caretPos - 1);
 			}
 
-			self.refreshState();
+			if (!self.isPending) {
+				self.refreshState();
+			}
+
 			self.updatePlaceholder();
 			self.updateOriginalInput({silent: silent});
 			self.positionDropdown();

--- a/test/api.js
+++ b/test/api.js
@@ -234,6 +234,27 @@
 			});
 		});
 
+		describe('removeItems()', function() {
+			var test;
+
+			before(function() {
+				test = setup_test('<select multiple>', {
+					valueField: 'value',
+					labelField: 'value',
+					options: [
+						{value: 'a'},
+						{value: 'b'},
+						{value: 'c'},
+						{value: 'x'},
+					]
+				});
+			});
+			it('should update "items" array', function() {
+				test.selectize.removeItems([ 'b', 'a' ]);
+				expect(test.selectize.items.indexOf('b')).to.be.equal(-1);
+				expect(test.selectize.items.indexOf('a')).to.be.equal(-1);
+			});
+		});
 		describe('addItem()', function() {
 			var test;
 


### PR DESCRIPTION
Let's you more efficiently bulk remove items by deferring updating certain css classes until all items have been processed, similar to addItems()
