### PR TITLE
Using hidden input type instead of text.

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -567,7 +567,7 @@
 	
 			$wrapper          = $('<div>').addClass(settings.wrapperClass).addClass(classes).addClass(inputMode);
 			$control          = $('<div>').addClass(settings.inputClass).addClass('items').appendTo($wrapper);
-			$control_input    = $('<input type="text" autocomplete="off" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
+			$control_input    = $('<input type="hidden" autocomplete="off" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 			$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 			$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
 			$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);


### PR DESCRIPTION
If the 'magic' field will be hidden in any way, why not use 'hidden' input type?

We're currently autofocusing the first text field when a modal is shown in our website. Sometimes the first text element was created by Selectize.js. Then we have to verify this special case before autofocus the form field. If it was a hidden field we wouldn't have this problem.
- All tests have passed.
