### PR TITLE
Revert accidental change to var name in bs 3 less

### DIFF
--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -16,7 +16,7 @@
 
 @import "selectize";
 
-@selectize-fonts-family: inherit;
+@selectize-font-family: inherit;
 @selectize-font-size: inherit;
 @selectize-line-height: @line-height-computed;
 


### PR DESCRIPTION
I'm fairly sure this was accidentally changed in 0b25771 – there are no references to `@selectize-fonts-family` in the rest of the repository and `selectize.less` and `selectize.bootstrap2.less` are both still using `@selectize-font-family`
