### PR TITLE
specify license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "description": "Selectize is a jQuery-based custom <select> UI control. Useful for tagging, contact lists, country selectors, etc.",
   "version": "0.12.1",
   "author": "Brian Reavis <brian@thirdroute.com>",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/brianreavis/selectize.js.git"


### PR DESCRIPTION
Add missing license information to package.json

Removes the warning on npm commands

```
npm WARN package.json selectize@0.12.1 No license field.
```
