### PR TITLE
Created click_to_edit plugin with example

### DIFF
--- a/examples/plugins.html
+++ b/examples/plugins.html
@@ -119,13 +119,13 @@
 				<h2>Plugin: "click_to_edit"</h2>
 				<div class="control-group">
 					<label for="input-sortable">Tags:</label>
-					<input type="text" id="input-sortable" class="input-sortable demo-default" value="click,to,edit,these,items">
+					<input type="text" id="input-sortable" class="input-sortable demo-default" value="click,to,edit,these,values">
 				</div>
 				<script>
 				$('.input-sortable').selectize({
 					plugins: ['click_to_edit'],
 					persist: false,
-					create: true
+					create: true,
 				});
 				</script>
 			</div>

--- a/examples/plugins.html
+++ b/examples/plugins.html
@@ -15,6 +15,7 @@
 		<script src="js/jquery.js"></script>
 		<script src="js/jqueryui.js"></script>
 		<script src="../dist/js/standalone/selectize.js"></script>
+		<script src="../src/plugins/click_to_edit/plugin.js"></script>
 		<script src="js/index.js"></script>
 	</head>
     <body>
@@ -113,6 +114,22 @@
 				})
 				</script>
 			</div>
+
+			<div class="demo">
+				<h2>Plugin: "click_to_edit"</h2>
+				<div class="control-group">
+					<label for="input-sortable">Tags:</label>
+					<input type="text" id="input-sortable" class="input-sortable demo-default" value="click,to,edit,these,items">
+				</div>
+				<script>
+				$('.input-sortable').selectize({
+					plugins: ['click_to_edit'],
+					persist: false,
+					create: true
+				});
+				</script>
+			</div>
+
 		</div>
 	</body>
 </html>

--- a/src/plugins/click_to_edit/plugin.js
+++ b/src/plugins/click_to_edit/plugin.js
@@ -1,0 +1,54 @@
+/**
+ * Plugin: "click_edit" (selectize.js)
+ * Copyright (c) 2013 Kris Salvador & contributors
+ *
+ * -- Description
+ * - Given an input selectize, users now have the ability to
+ * - click on a given item and edit them within the input.
+ *
+ * example gif: http://g.recordit.co/q391ZyVBVS.gif
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * @author Kris Salvador <krissalvador27@gmail.com>
+ */
+
+Selectize.define('click_to_edit', function( options ) {
+ var self = this;
+
+ options.text = options.text || function(option) {
+   return option[this.settings.labelField];
+ };
+
+ this.onClick = (function(e) {
+   var original = self.onClick;
+   
+   return function(e) {
+     var index, option, key;
+
+     if (e.toElement.className === 'item active') {
+       index = this.caretPos - 1;
+       if (index >= 0 && index < this.items.length) {
+         key = $(e.toElement).data('value');
+         option = this.options[key];
+
+         if (this.deleteSelection(e)) {
+           this.setTextboxValue(options.text.apply(this, [option]));
+           this.refreshOptions(true);
+         }
+         
+         e.preventDefault();
+         return;
+       }
+     }
+   };
+ })();
+
+ });

--- a/src/plugins/click_to_edit/plugin.js
+++ b/src/plugins/click_to_edit/plugin.js
@@ -21,34 +21,41 @@
  */
 
 Selectize.define('click_to_edit', function( options ) {
- var self = this;
+  var self = this;
 
- options.text = options.text || function(option) {
-   return option[this.settings.labelField];
- };
+  options.text = options.text || function(option) {
+    return option[this.settings.labelField];
+  };
 
- this.onClick = (function(e) {
-   var original = self.onClick;
+  this.onClick = (function(e) {
+    var original     = self.onClick,
+        maxItemIsOne = self.settings.maxItems === 1,
+        activeClass  = maxItemIsOne ? 'item active' : 'input active';
    
-   return function(e) {
-     var index, option, key;
+    return function(e) {
+      var index, option, key;
 
-     if (e.target.className === 'item active') {
-       index = this.caretPos - 1;
-       if (index >= 0 && index < this.items.length) {
-         key = $(e.target).data('value');
-         option = this.options[key];
+      if (e.target.className.indexOf(activeClass)) {
+        index = this.caretPos - 1;
+        if (index >= 0 && index < this.items.length) {
+          key = maxItemIsOne ? $(e.target).children().first().data('value') : $(e.target).data('value');
+          option = this.options[key];
 
-         if (this.deleteSelection(e)) {
-           this.setTextboxValue(options.text.apply(this, [option]));
-           this.refreshOptions(true);
-         }
+          if (this.deleteSelection(e)) {
+            // Remove item manually if maxItemIsOne since
+            // `e` is not on the item itself but the input
+            if (maxItemIsOne)
+              this.removeItem(key);
+
+            this.setTextboxValue(options.text.apply(this, [option]));
+            this.refreshOptions(true);
+          }
          
-         e.preventDefault();
-         return;
-       }
-     }
-   };
- })();
+          e.preventDefault();
+          return;
+        }
+      }
+    };
+  })();
 
- });
+});

--- a/src/plugins/click_to_edit/plugin.js
+++ b/src/plugins/click_to_edit/plugin.js
@@ -33,10 +33,10 @@ Selectize.define('click_to_edit', function( options ) {
    return function(e) {
      var index, option, key;
 
-     if (e.toElement.className === 'item active') {
+     if (e.target.className === 'item active') {
        index = this.caretPos - 1;
        if (index >= 0 && index < this.items.length) {
-         key = $(e.toElement).data('value');
+         key = $(e.target).data('value');
          option = this.options[key];
 
          if (this.deleteSelection(e)) {


### PR DESCRIPTION
- Allows users to edit individual selectize items within an input by clicking on them.

example: http://g.recordit.co/q391ZyVBVS.gif

Update:
- Updated to work with selectize called on `<select>` elements and `<inputs>` with maxItems === 1

example: http://g.recordit.co/ZZoImFdKgg.gif
