### PR TITLE
autoGrow graphical bug fix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -271,7 +271,7 @@ var autoGrow = function($input) {
 	var currentWidth = null;
 
 	var update = function(e, options) {
-		var value, keyCode, placeholder, width;
+		var value, keyCode, printable, placeholder, width;
 		var shift, character, selection;
 		e = e || window.event || {};
 		options = options || {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -283,7 +283,9 @@ var autoGrow = function($input) {
 		if (e.type && e.type.toLowerCase() === 'keypress') {
 			keyCode = e.which || e.keyCode;
 			printable = (
-				(keyCode != 44 && keyCode != KEY_COMMA) // comma
+				!(keyCode >= 44 && keyCode <= 45) && !(keyCode === KEY_COMMA) && // comma and insert
+				!(keyCode >= 33 && keyCode <= 40) && // arrow and scroll keys
+				(keyCode !== 12 && keyCode !== 19) // pause/break numkey 5
 			);
 
 			if (keyCode === KEY_DELETE || keyCode === KEY_BACKSPACE) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -281,9 +281,9 @@ var autoGrow = function($input) {
 
 		value = $input.val();
 		if (e.type && e.type.toLowerCase() === 'keypress') {
-			keyCode = e.keyCode;
+			keyCode = e.which || e.keyCode;
 			printable = (
-				(keyCode != 44) // comma
+				(keyCode != 44 && keyCode != KEY_COMMA) // comma
 			);
 
 			if (keyCode === KEY_DELETE || keyCode === KEY_BACKSPACE) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -282,6 +282,9 @@ var autoGrow = function($input) {
 		value = $input.val();
 		if (e.type && e.type.toLowerCase() === 'keypress') {
 			keyCode = e.keyCode;
+			printable = (
+				(keyCode != 44) // comma
+			);
 
 			if (keyCode === KEY_DELETE || keyCode === KEY_BACKSPACE) {
 				selection = getSelection($input[0]);
@@ -292,7 +295,7 @@ var autoGrow = function($input) {
 				} else if (keyCode === KEY_DELETE && typeof selection.start !== 'undefined') {
 					value = value.substring(0, selection.start) + value.substring(selection.start + 1);
 				}
-			} else {
+			} else if (printable) {
 				shift = e.shiftKey;
 				character = String.fromCharCode(e.keyCode);
 				if (shift) character = character.toUpperCase();

--- a/src/utils.js
+++ b/src/utils.js
@@ -271,7 +271,7 @@ var autoGrow = function($input) {
 	var currentWidth = null;
 
 	var update = function(e, options) {
-		var value, keyCode, printable, placeholder, width;
+		var value, keyCode, placeholder, width;
 		var shift, character, selection;
 		e = e || window.event || {};
 		options = options || {};
@@ -280,14 +280,8 @@ var autoGrow = function($input) {
 		if (!options.force && $input.data('grow') === false) return;
 
 		value = $input.val();
-		if (e.type && e.type.toLowerCase() === 'keydown') {
+		if (e.type && e.type.toLowerCase() === 'keypress') {
 			keyCode = e.keyCode;
-			printable = (
-				(keyCode >= 97 && keyCode <= 122) || // a-z
-				(keyCode >= 65 && keyCode <= 90)  || // A-Z
-				(keyCode >= 48 && keyCode <= 57)  || // 0-9
-				keyCode === 32 // space
-			);
 
 			if (keyCode === KEY_DELETE || keyCode === KEY_BACKSPACE) {
 				selection = getSelection($input[0]);
@@ -298,7 +292,7 @@ var autoGrow = function($input) {
 				} else if (keyCode === KEY_DELETE && typeof selection.start !== 'undefined') {
 					value = value.substring(0, selection.start) + value.substring(selection.start + 1);
 				}
-			} else if (printable) {
+			} else {
 				shift = e.shiftKey;
 				character = String.fromCharCode(e.keyCode);
 				if (shift) character = character.toUpperCase();
@@ -320,7 +314,7 @@ var autoGrow = function($input) {
 		}
 	};
 
-	$input.on('keydown keyup update blur', update);
+	$input.on('keydown keyup keypress update blur', update);
 	update();
 };
 


### PR DESCRIPTION
There is a graphical bug atm with the autoGrow function where if you type a character not triggering the printable var to be true the input field will not be resized correctly at first, which makes the text "drag" to the left for a quick moment. 
![autogrow graphical bug](https://cloud.githubusercontent.com/assets/12134822/12169881/1377ca48-b534-11e5-9890-d0e4bea13be7.png)

Also due to using keydown the character string will not have the correct character pressed (depending on keyboard language etc, like when adding @ on a keyboard that requires you to press alt gr + 2 the character would be 2 instead of @).

This is a suggestion that solves this graphical issue and will otherwise act the same way as the original script. (Only tested in FF and Chrome).

If my code is not used directly I hope it will at least help towards improving the original code and fixing this bug. 
