### PR TITLE
Fix unfocusable required select fields #733

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1600,7 +1600,8 @@ $.extend(Selectize.prototype, {
 		var invalid, self = this;
 		if (self.isRequired) {
 			if (self.items.length) self.isInvalid = false;
-			self.$control_input.prop('required', invalid);
+			self.$control_input.prop('required', self.$input.val() == '');
+			self.$input.prop('required', false);
 		}
 		self.refreshClasses();
 	},


### PR DESCRIPTION
A lot of people has been changing their own version of selectize.js to fix this problem. With this fix, I suppose most of them can start pointing to the official repository once again.

This fix was suggested by @dexcell
