### PR TITLE
Add an  event on refreshOptions

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -758,6 +758,7 @@
 				'option_add'      : 'onOptionAdd',
 				'option_remove'   : 'onOptionRemove',
 				'option_clear'    : 'onOptionClear',
+				'options_refresh' : 'onOptionsRefresh',
 				'optgroup_add'    : 'onOptionGroupAdd',
 				'optgroup_remove' : 'onOptionGroupRemove',
 				'optgroup_clear'  : 'onOptionGroupClear',
@@ -1588,6 +1589,7 @@
 				self.setActiveOption(null);
 				if (triggerDropdown && self.isOpen) { self.close(); }
 			}
+			self.trigger('options_refresh');
 		},
 	
 		/**

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -1367,6 +1367,7 @@
 				'option_add'      : 'onOptionAdd',
 				'option_remove'   : 'onOptionRemove',
 				'option_clear'    : 'onOptionClear',
+				'options_refresh' : 'onOptionsRefresh',
 				'optgroup_add'    : 'onOptionGroupAdd',
 				'optgroup_remove' : 'onOptionGroupRemove',
 				'optgroup_clear'  : 'onOptionGroupClear',
@@ -2197,6 +2198,7 @@
 				self.setActiveOption(null);
 				if (triggerDropdown && self.isOpen) { self.close(); }
 			}
+			self.trigger('options_refresh');
 		},
 	
 		/**

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -312,6 +312,7 @@ $.extend(Selectize.prototype, {
 			'option_add'      : 'onOptionAdd',
 			'option_remove'   : 'onOptionRemove',
 			'option_clear'    : 'onOptionClear',
+			'options_refresh' : 'onOptionsRefresh',
 			'optgroup_add'    : 'onOptionGroupAdd',
 			'optgroup_remove' : 'onOptionGroupRemove',
 			'optgroup_clear'  : 'onOptionGroupClear',
@@ -1145,6 +1146,7 @@ $.extend(Selectize.prototype, {
 			self.setActiveOption(null);
 			if (triggerDropdown && self.isOpen) { self.close(); }
 		}
+		self.trigger('options_refresh');
 	},
 
 	/**


### PR DESCRIPTION
This is quite a critical moment in the life cycle of the select and it should be triggered. I mainly needed it for using with perfect-scrollbar, so to update the scrollbar once the items have been refreshed.

Peace. :)
