### PR TITLE
Bump grunt-contrib-uglify to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-concat": "0.3.x",
     "grunt-contrib-copy": "0.4.x",
     "grunt-contrib-less": "~0.9.0",
-    "grunt-contrib-uglify": "0.2.x",
+    "grunt-contrib-uglify": "~1.0.1",
     "grunt-recess": "0.5.x",
     "grunt-replace": "0.4.x",
     "karma": "^0.12.31",


### PR DESCRIPTION
Default grunt task failed with the following:

```
Running "uglify:main" (uglify) task
File "dist/js/selectize.min.js" created.
Original: 76154 bytes.
Minified: 32893 bytes.
Gzipped:  Warning: Cannot assign to read only property 'subarray' of /*! selectize.js - v | https://github.com/brianreavis/selectize.js |
...
...
...
Use --force to continue.

Aborted due to warnings.
```

Quick google searched returned: https://github.com/gruntjs/grunt-contrib-uglify/issues/315. Bumping to 1.0.1 resolved the issue.

 `package.json` mixes use of `.X`, `^`, and `~`. Do you have a preference on how dependencies should be defined?
