### PR TITLE
Add `dropdownDirection` option (supports `up` and `down`).

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,6 +140,12 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>dropdownDirection</code></td>
+		<td valign="top">Direction in which dropdown will display. Currently accepts "up" and "down" as possible values.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>down</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>dropdownParent</code></td>
 		<td valign="top">The element the dropdown menu is appended to. This should be "body" or null. If null, the dropdown will be appended as a child of the selectize control.</td>
 		<td valign="top"><code>string</code></td>

--- a/examples/direction.html
+++ b/examples/direction.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7"><![endif]-->
+<!--[if IE 7]><html class="no-js lt-ie9 lt-ie8"><![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9"><![endif]-->
+<!--[if gt IE 8]><!--><html class="no-js"><!--<![endif]-->
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<title>Selectize.js Demo</title>
+		<meta name="description" content="">
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
+		<link rel="stylesheet" href="css/normalize.css">
+		<link rel="stylesheet" href="css/stylesheet.css">
+		<!--[if IE 8]><script src="js/es5.js"></script><![endif]-->
+		<script src="js/jquery.js"></script>
+		<script src="../dist/js/standalone/selectize.js"></script>
+		<script src="js/index.js"></script>
+	</head>
+    <body>
+		<div id="wrapper">
+			<h1>Selectize.js</h1>
+
+			<div class="demo">
+				<h2>Dropdown Direction Down w/ No Parent</h2>
+				<div class="control-group">
+					<label for="select-down-np">Down w/ No Parent:</label>
+					<select id="select-down-np" class="demo-default" placeholder="Select a person...">
+						<option value="">Select a person...</option>
+						<option value="4">Thomas Edison</option>
+						<option value="1">Nikola</option>
+						<option value="3">Nikola Tesla</option>
+						<option value="5">Arnold Schwarzenegger</option>
+					</select>
+				</div>
+				<script>
+				$('#select-down-np').selectize({
+					create: true,
+					sortField: {
+						field: 'text',
+						direction: 'asc'
+					}
+				});
+				</script>
+			</div>
+
+			<div class="demo">
+				<h2>Dropdown Direction Down w/ Parent</h2>
+				<div class="control-group">
+					<label for="select-down">Down w/ Parent:</label>
+					<select id="select-down" class="demo-default" placeholder="Select a person...">
+						<option value="">Select a person...</option>
+						<option value="4">Thomas Edison</option>
+						<option value="1">Nikola</option>
+						<option value="3">Nikola Tesla</option>
+						<option value="5">Arnold Schwarzenegger</option>
+					</select>
+				</div>
+				<script>
+				$('#select-down').selectize({
+					dropdownParent: 'body',
+					create: true,
+					sortField: {
+						field: 'text',
+						direction: 'asc'
+					}
+				});
+				</script>
+			</div>
+
+			<div class="demo">
+				<h2>Dropdown Direction Up w/ No Parent</h2>
+				<div class="control-group">
+					<label for="select-up-np">Up w/ No Parent:</label>
+					<select id="select-up-np" class="demo-default" placeholder="Select a person...">
+						<option value="">Select a person...</option>
+						<option value="4">Thomas Edison</option>
+						<option value="1">Nikola</option>
+						<option value="3">Nikola Tesla</option>
+						<option value="5">Arnold Schwarzenegger</option>
+					</select>
+				</div>
+				<script>
+				$('#select-up-np').selectize({
+					dropdownDirection: 'up',
+					create: true,
+					sortField: {
+						field: 'text',
+						direction: 'asc'
+					}
+				});
+				</script>
+			</div>
+
+			<div class="demo">
+				<h2>Dropdown Direction Up w/ Parent</h2>
+				<div class="control-group">
+					<label for="select-up">Up w/ Parent:</label>
+					<select id="select-up" class="demo-default" placeholder="Select a person...">
+						<option value="">Select a person...</option>
+						<option value="4">Thomas Edison</option>
+						<option value="1">Nikola</option>
+						<option value="3">Nikola Tesla</option>
+						<option value="5">Arnold Schwarzenegger</option>
+					</select>
+				</div>
+				<script>
+				$('#select-up').selectize({
+					dropdownParent: 'body',
+					dropdownDirection: 'up',
+					create: true,
+					sortField: {
+						field: 'text',
+						direction: 'asc'
+					}
+				});
+				</script>
+			</div>
+
+		</div>
+	</body>
+</html>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -43,7 +43,7 @@ Selectize.defaults = {
 	inputClass: 'selectize-input',
 	dropdownClass: 'selectize-dropdown',
 	dropdownContentClass: 'selectize-dropdown-content',
-
+	dropdownDirection: 'down',
 	dropdownParent: null,
 
 	copyClassesToDropdown: true,

--- a/src/less/selectize.bootstrap2.less
+++ b/src/less/selectize.bootstrap2.less
@@ -67,9 +67,14 @@
 	margin: 2px 0 0 0;
 	z-index: @zindexDropdown;
 	border: 1px solid @dropdownBorder;
-	border-radius: @baseBorderRadius;
+	.selectize-border-radius(@selectize-border-radius);
 	.box-shadow(0 5px 10px rgba(0,0,0,.2));
 
+	&.dropup {
+		margin: 0 0 2px 0;
+		border: 1px solid @dropdownBorder;
+		.selectize-border-radius(@selectize-border-radius);
+	}
 	.optgroup-header {
 		font-size: 11px;
 		font-weight: bold;
@@ -103,7 +108,8 @@
 .selectize-input {
 	.transition(~"border linear .2s, box-shadow linear .2s");
 
-	&.dropdown-active {
+	&.dropdown-active,
+	&.dropdown-active.dropup {
 		.selectize-border-radius(@selectize-border-radius);
 	}
 	&.dropdown-active::before {

--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -73,6 +73,13 @@
 	border: 1px solid @dropdown-border;
 	.selectize-border-radius(@border-radius-base);
 	.selectize-box-shadow(0 6px 12px rgba(0,0,0,.175));
+
+	&.dropup {
+		margin: 0 0 2px 0;
+		border: 1px solid @dropdown-fallback-border;
+		border: 1px solid @dropdown-border;
+		.selectize-border-radius(@border-radius-base);
+	}
 }
 
 .selectize-dropdown {
@@ -103,7 +110,8 @@
 .selectize-input {
 	min-height: @input-height-base;
 
-	&.dropdown-active {
+	&.dropdown-active,
+	&.dropdown-active.dropup {
 		.selectize-border-radius(@selectize-border-radius);
 	}
 	&.dropdown-active::before {

--- a/src/less/selectize.less
+++ b/src/less/selectize.less
@@ -136,6 +136,9 @@
 	&.dropdown-active {
 		.selectize-border-radius(@selectize-border-radius @selectize-border-radius 0 0);
 	}
+	&.dropdown-active.dropup {
+		.selectize-border-radius(0 0 @selectize-border-radius @selectize-border-radius);
+	}
 
 	> * {
 		vertical-align: baseline;
@@ -191,6 +194,23 @@
 	clear: left;
 }
 
+.selectize-input.dropdown-active {
+	&::before {
+		content: ' ';
+		display: block;
+		position: absolute;
+		background: @selectize-color-dropdown-border-top;
+		height: 1px;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
+	&[data-dropdown-direction='up']::before {
+		top: 0;
+		bottom: auto;
+	}
+}
+
 .selectize-input.dropdown-active::before {
 	content: ' ';
 	display: block;
@@ -213,6 +233,12 @@
 	.selectize-box-shadow(0 1px 3px rgba(0,0,0,0.1));
 	.selectize-border-radius(0 0 @selectize-border-radius @selectize-border-radius);
 
+	&.dropup {
+		margin: 0 0 -1px 0;
+		border-top: @selectize-dropdown-border;
+		border-bottom: 0 none;
+		.selectize-border-radius(@selectize-border-radius @selectize-border-radius 0 0);
+	}
 	[data-selectable] {
 		cursor: pointer;
 		overflow: hidden;

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1145,6 +1145,8 @@ $.extend(Selectize.prototype, {
 			self.setActiveOption(null);
 			if (triggerDropdown && self.isOpen) { self.close(); }
 		}
+
+		self.positionDropdown();
 	},
 
 	/**

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1625,8 +1625,12 @@ $.extend(Selectize.prototype, {
 			.toggleClass('full', isFull).toggleClass('not-full', !isFull)
 			.toggleClass('input-active', self.isFocused && !self.isInputHidden)
 			.toggleClass('dropdown-active', self.isOpen)
+			.toggleClass('dropup', self.dropUp)
 			.toggleClass('has-options', !$.isEmptyObject(self.options))
 			.toggleClass('has-items', self.items.length > 0);
+
+		self.$dropdown
+			.toggleClass('dropup', self.dropUp);
 
 		self.$control_input.data('grow', !isFull && !isLocked);
 	},
@@ -1730,7 +1734,12 @@ $.extend(Selectize.prototype, {
 	positionDropdown: function() {
 		var $control = this.$control;
 		var offset = this.settings.dropdownParent === 'body' ? $control.offset() : $control.position();
-		offset.top += $control.outerHeight(true);
+
+		if (this.dropUp = this.settings.dropdownDirection === 'up') {
+			offset.top -= this.$dropdown.outerHeight(true);
+		} else {
+			offset.top += $control.outerHeight(true);
+		}
 
 		this.$dropdown.css({
 			width : $control.outerWidth(),

--- a/test/positioning.js
+++ b/test/positioning.js
@@ -1,0 +1,58 @@
+(function() {
+
+	var click = function(el, cb) {
+		syn.click(el).delay(350, cb);
+	};
+
+	var testPositioning = function (options, callback) {
+		var test = setup_test('<select multiple>' +
+			'<option value="a">A</option>' +
+			'<option value="b">B</option>' +
+		'</select>', options);
+
+		click(test.selectize.$control, function() {
+			var controlCoordinates = getCoordinates(test.selectize.$control);
+			var dropdownCoordinates = getCoordinates(test.selectize.$dropdown);
+
+			callback(controlCoordinates, dropdownCoordinates);
+		});
+	};
+
+	var getCoordinates = function ($el) {
+		var offset = $el.offset();
+
+		return {
+			top: offset.top,
+			left: offset.left,
+			bottom: offset.top + $el.outerHeight(),
+			right: offset.left + $el.outerWidth()
+		};
+	}
+
+	describe('Positioning', function() {
+
+		it('should place dropdown below control when using default dropdownDirection', function(done) {
+			testPositioning({}, function (controlCoordinates, dropdownCoordinates) {
+				// the dropdown by default has a margin-top of -1
+				expect(controlCoordinates.bottom).to.equal(dropdownCoordinates.top + 1);
+				expect(controlCoordinates.left).to.equal(dropdownCoordinates.left);
+				expect(controlCoordinates.right).to.equal(dropdownCoordinates.right);
+				done();
+			});
+		});
+
+		it('should place dropdown above control when using dropdownDirection: up', function(done) {
+			testPositioning({
+				dropdownDirection: 'up'
+			}, function (controlCoordinates, dropdownCoordinates) {
+				// the dropdown by default has a margin-bottom of -1
+				expect(controlCoordinates.top).to.equal(dropdownCoordinates.bottom - 1);
+				expect(controlCoordinates.left).to.equal(dropdownCoordinates.left);
+				expect(controlCoordinates.right).to.equal(dropdownCoordinates.right);
+				done();
+			});
+		});
+
+	});
+
+})();

--- a/test/positioning.js
+++ b/test/positioning.js
@@ -10,15 +10,19 @@
 			'<option value="b">B</option>' +
 		'</select>', options);
 
-		click(test.selectize.$control, function() {
-			var controlCoordinates = getCoordinates(test.selectize.$control);
-			var dropdownCoordinates = getCoordinates(test.selectize.$dropdown);
-
-			callback(controlCoordinates, dropdownCoordinates);
+		click(test.selectize.$control, function () {
+			callback(test);
 		});
 	};
 
-	var getCoordinates = function ($el) {
+	var getCoordinates = function(test) {
+		var controlCoordinates = getElCoordinates(test.selectize.$control);
+		var dropdownCoordinates = getElCoordinates(test.selectize.$dropdown);
+
+		return { control: controlCoordinates, dropdown: dropdownCoordinates };
+	};
+
+	var getElCoordinates = function ($el) {
 		var offset = $el.offset();
 
 		return {
@@ -27,16 +31,18 @@
 			bottom: offset.top + $el.outerHeight(),
 			right: offset.left + $el.outerWidth()
 		};
-	}
+	};
 
 	describe('Positioning', function() {
 
 		it('should place dropdown below control when using default dropdownDirection', function(done) {
-			testPositioning({}, function (controlCoordinates, dropdownCoordinates) {
+			testPositioning({}, function (test) {
+				var coordinates = getCoordinates(test);
+
 				// the dropdown by default has a margin-top of -1
-				expect(controlCoordinates.bottom).to.equal(dropdownCoordinates.top + 1);
-				expect(controlCoordinates.left).to.equal(dropdownCoordinates.left);
-				expect(controlCoordinates.right).to.equal(dropdownCoordinates.right);
+				expect(coordinates.control.bottom).to.equal(coordinates.dropdown.top + 1);
+				expect(coordinates.control.left).to.equal(coordinates.dropdown.left);
+				expect(coordinates.control.right).to.equal(coordinates.dropdown.right);
 				done();
 			});
 		});
@@ -44,12 +50,30 @@
 		it('should place dropdown above control when using dropdownDirection: up', function(done) {
 			testPositioning({
 				dropdownDirection: 'up'
-			}, function (controlCoordinates, dropdownCoordinates) {
+			}, function (test) {
+				var coordinates = getCoordinates(test);
+
 				// the dropdown by default has a margin-bottom of -1
-				expect(controlCoordinates.top).to.equal(dropdownCoordinates.bottom - 1);
-				expect(controlCoordinates.left).to.equal(dropdownCoordinates.left);
-				expect(controlCoordinates.right).to.equal(dropdownCoordinates.right);
+				expect(coordinates.control.top).to.equal(coordinates.dropdown.bottom - 1);
+				expect(coordinates.control.left).to.equal(coordinates.dropdown.left);
+				expect(coordinates.control.right).to.equal(coordinates.dropdown.right);
 				done();
+			});
+		});
+
+		it('should keep dropdown locked above control when using dropdownDirection: up', function(done) {
+			testPositioning({
+				dropdownDirection: 'up'
+			}, function (test) {
+				syn.type('a', test.selectize.$control_input).delay(0, function() {
+					var coordinates = getCoordinates(test);
+
+					// the dropdown by default has a margin-bottom of -1
+					expect(coordinates.control.top).to.equal(coordinates.dropdown.bottom - 1);
+					expect(coordinates.control.left).to.equal(coordinates.dropdown.left);
+					expect(coordinates.control.right).to.equal(coordinates.dropdown.right);
+					done();
+				});
 			});
 		});
 


### PR DESCRIPTION
Many of the core concepts here come from https://github.com/selectize/selectize.js/pull/437/files. Thank you @streamside for the original work. We have stripped out `auto` functionality, so that these pieces may be implemented in more manageable chunks.

A few thoughts:
- The bootstrap styles I had to write were just overrides of the new styles I declared in selectize.less. Ideally there would be a core selectize stylesheet with required/shared styles, and then additionally theme styles. This would remove the necessity for these overrides. (Sits outside of the scope of this PR).
- QA was rather manual due to varying themes. Karma appears to be well suited for testing the functionality of selectize, but lacks the necessary capability to catch visual "breaks". You could possibly take screenshots and diff the images (may be the only way to have a high degree of confidence in visual consistency accross browsers)?
- Adding new styles (like drop for example), still requires the human eye to confirm it is behaving correctly. In the case of this feature I created examples/direction.html to confirm visuals behaved correctly across themes.
- A new test file was added, `positioning.js`. It should prove useful for future work on `dropdownDirection: auto`... But I do not want to note, it is not perfect. The tests are based on my understanding of how things are/should be positioned. The tests are only as good as my understanding. If you have thoughts on a more robust solution, I'd be happy to implement.

---

All in all, I have a high degree of confidence no breaking changes were implemented, and that the new functionality is working as expected across each theme.  While I believe, due to the complexity in the changes made, that everything is behaving correctly across browsers, I cannot guarantee it because I did not manually check each browser.
