### PR TITLE
force control input update during create, before item addition

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1562,6 +1562,8 @@ $.extend(Selectize.prototype, {
 			var value = hash_key(data[self.settings.valueField]);
 			if (typeof value !== 'string') return callback();
 
+			self.$control_input.triggerHandler('update', {force: true})
+
 			self.setTextboxValue('');
 			self.addOption(data);
 			self.setCaret(caret);


### PR DESCRIPTION
The input width doesn't reset during an asynchronous create. This results in the placeholder text being cut off. In this gif, the create callback doesn't get called until after a popup resolves. If the create action callback fails to create a new item (when the popup is cancelled), then the placeholder text remains cutoff.

![selectize_bug](https://cloud.githubusercontent.com/assets/1091338/15978273/4698c296-2f1a-11e6-8e27-4805d79242a4.gif)

Forcing the update as the create function resolves seems to provide the functionality I want.
