### PR TITLE
Get rid of Error: Invalid US-ASCII character "\xE2"

### DIFF
--- a/dist/less/selectize.bootstrap3.less
+++ b/dist/less/selectize.bootstrap3.less
@@ -1,6 +1,6 @@
 /**
  * selectize.bootstrap3.css (v0.12.2) - Bootstrap 3 Theme
- * Copyright (c) 2013–2015 Brian Reavis & contributors
+ * Copyright (c) 2013-2015 Brian Reavis & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:


### PR DESCRIPTION
To get rid of error when I insert CSS generated from this LESS into mine SASS file.
Error: Invalid US-ASCII character "\xE2"
