### PR TITLE
Fix highlight not working after first highlight insert #1098

### DIFF
--- a/src/contrib/highlight.js
+++ b/src/contrib/highlight.js
@@ -37,3 +37,16 @@ var highlight = function($element, pattern) {
 		highlight(this);
 	});
 };
+
+/**
+ * removeHighlight fn copied from highlight v5 and
+ * edited to remove with() and pass js strict mode
+ */
+jQuery.fn.removeHighlight = function() {
+	return this.find("span.highlight").each(function() {
+		this.parentNode.firstChild.nodeName;
+		var parent = this.parentNode;
+		parent.replaceChild(this.firstChild, this);
+		parent.normalize();
+	}).end();
+};

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1100,6 +1100,7 @@ $.extend(Selectize.prototype, {
 
 		// highlight matching terms inline
 		if (self.settings.highlight && results.query.length && results.tokens.length) {
+			$dropdown_content.removeHighlight();
 			for (i = 0, n = results.tokens.length; i < n; i++) {
 				highlight($dropdown_content, results.tokens[i].regex);
 			}


### PR DESCRIPTION
The highlight did not work correctly after the first highlight happened. Most likely it would only highlight the first letter.

[Newer version of the highlight function](http://johannburkard.de/resources/Johann/jquery.highlight-5.js) have added a removeHighlight() function that allows to reset the strings between each highlights and then getting a good result.

Problem, that version does not use Regexp to match the highlight anymore and their file does not pass the strict mode as is so it can't be commited to selectize.

It's a bit weird to have that contrib commited into the repo. I don't know if it's wise to edit it in our code or not or to update it or to remove it, or... So I've just made the minimal changes to fix the issue without changing much. I've copied their removeHighlight() fn and edited it to pass strict mode.

From issue #1098 
