### PR TITLE
Remove keypress checks to fix autogrow jitter for some characters.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -271,41 +271,13 @@ var autoGrow = function($input) {
 	var currentWidth = null;
 
 	var update = function(e, options) {
-		var value, keyCode, printable, placeholder, width;
-		var shift, character, selection;
+		var value, placeholder, width;
+
 		e = e || window.event || {};
 		options = options || {};
 
-		if (e.metaKey || e.altKey) return;
 		if (!options.force && $input.data('grow') === false) return;
-
 		value = $input.val();
-		if (e.type && e.type.toLowerCase() === 'keydown') {
-			keyCode = e.keyCode;
-			printable = (
-				(keyCode >= 97 && keyCode <= 122) || // a-z
-				(keyCode >= 65 && keyCode <= 90)  || // A-Z
-				(keyCode >= 48 && keyCode <= 57)  || // 0-9
-				keyCode === 32 // space
-			);
-
-			if (keyCode === KEY_DELETE || keyCode === KEY_BACKSPACE) {
-				selection = getSelection($input[0]);
-				if (selection.length) {
-					value = value.substring(0, selection.start) + value.substring(selection.start + selection.length);
-				} else if (keyCode === KEY_BACKSPACE && selection.start) {
-					value = value.substring(0, selection.start - 1) + value.substring(selection.start + 1);
-				} else if (keyCode === KEY_DELETE && typeof selection.start !== 'undefined') {
-					value = value.substring(0, selection.start) + value.substring(selection.start + 1);
-				}
-			} else if (printable) {
-				shift = e.shiftKey;
-				character = String.fromCharCode(e.keyCode);
-				if (shift) character = character.toUpperCase();
-				else character = character.toLowerCase();
-				value += character;
-			}
-		}
 
 		placeholder = $input.attr('placeholder');
 		if (!value && placeholder) {
@@ -320,7 +292,7 @@ var autoGrow = function($input) {
 		}
 	};
 
-	$input.on('keydown keyup update blur', update);
+	$input.on('update blur input', update);
 	update();
 };
 


### PR DESCRIPTION
Addresses issue where common, non-(a-z/0-9) characters jogged left until a key was released.

https://github.com/selectize/selectize.js/issues/809

This PR uses the input event to avoid printable character checks entirely. Instead, just check the field value after something's been entered/removed/pasted/etc.

This breaks IE8/9 compatibility, so a [polyfill](http://benalpert.com/2013/06/18/a-near-perfect-oninput-shim-for-ie-8-and-9.html) may be required. This may not be acceptable, depending on long-term roadmap.

![selectize](https://cloud.githubusercontent.com/assets/242008/16710712/677754aa-45fe-11e6-9807-a87619f181db.gif)

Updated demo page here: https://billiam.github.io/selectize.js
