### PR TITLE
"highlightContainerSelector" option to control highlighting in options

### DIFF
--- a/src/contrib/highlight.js
+++ b/src/contrib/highlight.js
@@ -37,3 +37,17 @@ var highlight = function($element, pattern) {
 		highlight(this);
 	});
 };
+
+var removeHighlight = function( $element ){
+	
+	var removeHighlight = function(node) {
+		node.parentNode.firstChild.nodeName;
+		var parent = node.parentNode;
+		parent.replaceChild(node.firstChild, node);
+		parent.normalize();
+	};
+	
+	return $element.find("span.highlight").each(function() {
+		removeHighlight(this);
+	});
+};

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -12,6 +12,7 @@ Selectize.defaults = {
 	createOnBlur: false,
 	createFilter: null,
 	highlight: true,
+	highlightContainerSelector: null,
 	openOnFocus: true,
 	maxOptions: 1000,
 	maxItems: null,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1100,8 +1100,13 @@ $.extend(Selectize.prototype, {
 
 		// highlight matching terms inline
 		if (self.settings.highlight && results.query.length && results.tokens.length) {
+			removeHighlight( $dropdown_content );
 			for (i = 0, n = results.tokens.length; i < n; i++) {
-				highlight($dropdown_content, results.tokens[i].regex);
+				if( self.settings.highlightContainerSelector ) {
+					highlight($dropdown_content.find( self.settings.highlightContainerSelector ), results.tokens[i].regex);
+				}else{
+					highlight($dropdown_content, results.tokens[i].regex);
+				}
 			}
 		}
 

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -137,6 +137,58 @@
 		});
 
 		describe('typing in input', function() {
+			
+			it('should highlight matches', function(done) {
+				
+				var test = setup_test('<select>' +
+					'<option value="">Select an option...</option>' +
+					"<option data-data='{ \"value\": \"Hello world\", \"text\": \"Hello world\" }' value='Hello world'>Hello world</option>" +
+					"<option data-data='{ \"value\": \"World\", \"text\": \"World\" }' value='World'>World</option>" +
+				'</select>', {
+					create: false,
+					persist: false
+				});
+				
+				click(test.selectize.$control, function(){
+					syn.type('world', test.selectize.$control_input)
+					.delay(1000, function(){
+						expect($('[data-value="Hello world"] span.highlight', test.selectize.$dropdown).length).to.be.equal(1);
+						expect($('[data-value="World"] span.highlight', test.selectize.$dropdown).length).to.be.equal(1);
+						expect($('[data-value="Hello world"] span.highlight', test.selectize.$dropdown).text()).to.be.equal('world');
+						expect($('[data-value="World"] span.highlight', test.selectize.$dropdown).text()).to.be.equal('World');
+						done();
+					});
+				});
+				
+			});
+			
+			it('should highlight matches within specified container', function(done) {
+				
+				var test = setup_test('<select>' +
+					'<option value="">Select an option...</option>' +
+					"<option data-data='{ \"value\": \"Hello world\", \"text\": \"Hello world\" }' value='Hello world'>Hello world</option>" +
+					"<option data-data='{ \"value\": \"World\", \"text\": \"World\" }' value='World'>World</option>" +
+				'</select>', {
+					create: false,
+					persist: false,
+					render: {
+						option: function(item, escape) {
+							return '<div><span class="highlight-container">'+escape(item.value)+'</span> <span class="no-highlight-container">'+escape(item.value)+'</span></div>'
+						}
+					},
+					highlightContainerSelector: '.highlight-container'
+				});
+				
+				click(test.selectize.$control, function(){
+					syn.type('world', test.selectize.$control_input)
+					.delay(1000, function(){
+						expect($('[data-value="Hello world"] .highlight-container span.highlight', test.selectize.$dropdown).length).to.be.equal(1);
+						expect($('[data-value="Hello world"] .no-highlight-container span.highlight', test.selectize.$dropdown).length).to.be.equal(0);
+						done();
+					});
+				});
+				
+			});
 
 			it('should filter results', function(done) {
 				var test = setup_test('<select>' +


### PR DESCRIPTION
This pull requests contains two changes:
1. Add **highlightContainerSelector** options which can contain css-selector. If option is set - highlight will work only for specified element in options markup.
2. Fixes highlighting bug when only first character was highlighted ( https://github.com/selectize/selectize.js/issues/1098 ). This pull request contains similar code to already existing pull request ( https://github.com/skimi/selectize.js/commit/8d2d76b56d58180017253a6bd6a1dd1a782ff1da ) related to this issue, so these changes can conflict.
