### PR TITLE
No need to remove the selected item matching if there is no input

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1487,6 +1487,10 @@ $.extend(Selectize.prototype, {
 		var self = this;
 		var $item, i, idx;
 
+		if (!value) {
+			return false;
+		}
+
 		$item = (value instanceof $) ? value : self.getItem(value);
 		value = hash_key($item.attr('data-value'));
 		i = self.items.indexOf(value);


### PR DESCRIPTION
Return false from `removeItem` if there is no input.
