### PR TITLE
Properly escape CSS notation

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -129,7 +129,8 @@ $.extend(Selectize.prototype, {
 
 		if(inputId = $input.attr('id')) {
 			$control_input.attr('id', inputId + '-selectized');
-			$('label[for='+inputId+']').attr('for', inputId + '-selectized');
+			var inputIdEscaped=inputId.replace( /(:|\.|\[|\]|,)/g, "\\$1" );
+			$('label[for='+inputIdEscaped+']').attr('for', inputId + '-selectized');
 		}
 
 		if(self.settings.copyClassesToDropdown) {


### PR DESCRIPTION
Small problem caused by #755  as it does not escape CSS notation within the id attribute properly. Compare: https://learn.jquery.com/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation/
