### PR TITLE
Removed the non-ASCII '–' character within the license part which causi…

### DIFF
--- a/src/.wrapper.js
+++ b/src/.wrapper.js
@@ -1,6 +1,6 @@
 /**
  * selectize.js (v@@version)
- * Copyright (c) 2013–2015 Brian Reavis & contributors
+ * Copyright (c) 2013-2015 Brian Reavis & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/src/less/.wrapper.css
+++ b/src/less/.wrapper.css
@@ -1,6 +1,6 @@
 /**
  * selectize.css (v@@version)
- * Copyright (c) 2013–2015 Brian Reavis & contributors
+ * Copyright (c) 2013-2015 Brian Reavis & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/src/less/selectize.bootstrap2.less
+++ b/src/less/selectize.bootstrap2.less
@@ -1,6 +1,6 @@
 /**
  * selectize.bootstrap2.css (v@@version) - Bootstrap 2 Theme
- * Copyright (c) 2013–2015 Brian Reavis & contributors
+ * Copyright (c) 2013-2015 Brian Reavis & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -1,6 +1,6 @@
 /**
  * selectize.bootstrap3.css (v@@version) - Bootstrap 3 Theme
- * Copyright (c) 2013–2015 Brian Reavis & contributors
+ * Copyright (c) 2013-2015 Brian Reavis & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/src/less/selectize.default.less
+++ b/src/less/selectize.default.less
@@ -1,6 +1,6 @@
 /**
  * selectize.default.css (v@@version) - Default Theme
- * Copyright (c) 2013–2015 Brian Reavis & contributors
+ * Copyright (c) 2013-2015 Brian Reavis & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/src/less/selectize.legacy.less
+++ b/src/less/selectize.legacy.less
@@ -1,6 +1,6 @@
 /**
  * selectize.legacy.css (v@@version) - Default Theme
- * Copyright (c) 2013–2015 Brian Reavis & contributors
+ * Copyright (c) 2013-2015 Brian Reavis & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:


### PR DESCRIPTION
**Problem:**
Found an error when compiling scss on Shopify with the following error message:

`SCSS file is not UTF-8 encoded`

The non-ASCII character resulting Shopify to fail compiling the whole scss files and giving you a _failed-compiled_ output file as shown below on Chrome:

![image](https://cloud.githubusercontent.com/assets/396260/17401465/0edacafa-5a78-11e6-9e53-b74356f02eeb.png)

![image](https://cloud.githubusercontent.com/assets/396260/17401487/267d3d3c-5a78-11e6-9630-31e7190c49cf.png)

**Root cause:**
Results of the non-ASCII character found inside the the `less` directory _(as the error occurred only for scss on Shopify)_: 

![image](https://cloud.githubusercontent.com/assets/396260/17401417/bfc903b4-5a77-11e6-9b2e-7e2dbb346cfd.png)

The character:

![image](https://cloud.githubusercontent.com/assets/396260/17401853/261cde54-5a7a-11e6-99ee-7f426d368ebf.png)

Results of files inside `src` directory containing the character:

![image](https://cloud.githubusercontent.com/assets/396260/17401439/e7ab4fea-5a77-11e6-880d-abed70009c17.png)

**Solution:**
Removed the non-ASCII '`–`' em-dash(??) character within the license part of every occurring file at the line of:

`* Copyright (c) 2013–2015 Brian Reavis & contributors`
