### PR TITLE
Adding config value to search nested fields

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -978,7 +978,8 @@ $.extend(Selectize.prototype, {
 		return {
 			fields      : settings.searchField,
 			conjunction : settings.searchConjunction,
-			sort        : sort
+			sort        : sort,
+			nesting     : settings.nesting
 		};
 	},
 


### PR DESCRIPTION
Adding this config option will let sifter look through subfields for the search query.

Code below includes some 'searchField' values as an example.

In addition to passing the nesting value to the correct sifter config, this also requires the addition of the 'nesting: true' key and value to your selectize config:

```
{
  searchField: ['field_a', 'field_b', 'some.dot_notation.field_name'], 
  nesting: true
}
```

Whether you want to add this to the base level of the config is up to you. You could also add it to a second level such as:

```
{
  searchField: ['field_a', 'field_b', 'some.dot_notation.field_name'], 
  searchFieldOptions:  [{nesting: true}],
}
```

which would require extra config processing, but might make the placement of those options more clear.

If desired I can likely come up with a short example to add to the documentation as well. It would be worth noting that the subfield searched may also be displayed if highlighting is desired.
