### PR TITLE
Improve handling under iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+*  Fix open keyboard bug under iOS after closing selection (#1127)
+
+   *@zeitiger*
+
 *  Fix highlighting more than one character (#1099, #1098)
 
    *@skimi*

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1741,6 +1741,7 @@ $.extend(Selectize.prototype, {
 
 		if (self.settings.mode === 'single' && self.items.length) {
 			self.hideInput();
+			self.$control_input.blur(); // close keyboard on iOS
 		}
 
 		self.isOpen = false;

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -29,17 +29,34 @@
 
 		it('should close dropdown after selection made if closeAfterSelect: true', function(done) {
 			var test = setup_test('<select multiple>' +
-					'<option value="a">A</option>' +
-					'<option value="b">B</option>' +
+				'<option value="a">A</option>' +
+				'<option value="b">B</option>' +
 				'</select>', {closeAfterSelect: true});
 
-				click(test.selectize.$control, function() {
-					click($('[data-value=a]', test.selectize.$dropdown_content), function() {
-						expect(test.selectize.isOpen).to.be.equal(false);
-						expect(test.selectize.isFocused).to.be.equal(true);
-						done();
-					});
+			click(test.selectize.$control, function() {
+				click($('[data-value=a]', test.selectize.$dropdown_content), function() {
+					expect(test.selectize.isOpen).to.be.equal(false);
+					expect(test.selectize.isFocused).to.be.equal(true);
+					done();
 				});
+			});
+		});
+
+		it('should close and blur dropdown after selection made if closeAfterSelect: true and in single mode' , function(done) {
+			var test = setup_test('<select>' +
+				'<option value="a">A</option>' +
+				'<option value="b">B</option>' +
+				'</select>', {closeAfterSelect: true});
+
+			click(test.selectize.$control, function() {
+				expect(test.selectize.isOpen).to.be.equal(true);
+				expect(test.selectize.isFocused).to.be.equal(true);
+				click($('[data-value=a]', test.selectize.$dropdown_content), function() {
+					expect(test.selectize.isOpen).to.be.equal(false);
+					expect(test.selectize.isFocused).to.be.equal(false);
+					done();
+				});
+			});
 		});
 
 		describe('clicking control', function() {


### PR DESCRIPTION
Under iOS 
- Open selectize widget with closeAfterSelection: true
- Onscreen keyboard appears 
- Select something (independent of keyboard usage)
- Selectize close correctly, but onscreen keyboard keeps open

This pull request fix this issue, with removing focus on hidden text input field, within close event handling.
