### PR TITLE
Duplicated options in different optgroups doesn't render correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+*  Fix render bug of options with duplicated values in different option groups (#1128)
+
+   *@zeitiger*
+   
 *  Output friendly error message when Microplguin is missing (#1137).
    Special thanks to @styxxx for proposing the improvement.
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1087,7 +1087,8 @@ $.extend(Selectize.prototype, {
 					groups[optgroup] = document.createDocumentFragment();
 					groups_order.push(optgroup);
 				}
-				groups[optgroup].appendChild(option_html);
+				// a child could only have one parent, so if you have more parents clone the child
+				groups[optgroup].appendChild((!j) ? option_html : option_html.cloneNode(true));
 			}
 		}
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -86,6 +86,24 @@
 					'Group 2': {label: 'Group 2', val: 'Group 2', $order: 4}
 				});
 			});
+			it('should render optgroups with duplicated options correctly', function(done) {
+				var test = setup_test(['<select>',
+					'<optgroup label="Group 1">',
+					'<option value="a">Item A</option>',
+					'<option value="b">Item B</option>',
+					'</optgroup>',
+					'<optgroup label="Group 2">',
+					'<option value="a">Item A</option>',
+					'<option value="b">Item B</option>',
+					'</optgroup>',
+					'</select>'].join(''), {});
+				test.selectize.refreshOptions(true);
+				window.setTimeout(function() {
+					assert.equal(test.selectize.$dropdown_content.find('.optgroup').length, 2, 'expect 2 optgroups');
+					assert.equal(test.selectize.$dropdown_content.find('.option').length, 4, 'expect 4 options');
+					done();
+				}, 0);
+			});
 			it('should add options in text form (no html entities)', function() {
 				var test = setup_test('<select><option selected value="a">&lt;hi&gt;</option></select>', {});
 				expect(test.selectize.options['a'].text).to.be.equal('<hi>');


### PR DESCRIPTION
Duplicated options (options with the same value) will be render only once within last occurrence

This pull request includes a test case to reproduce the problem and the bugfix for that. I'm open for discussion to make this bugfix better :-)

Have a nice day 😸 
