### PR TITLE
feature: allow to disable single options or complete optgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+*  New feature: allow to disable single options or complete optgroups
+
+   *@zeitiger*
+
 *  Fix open keyboard bug under iOS after closing selection (#1127)
 
    *@zeitiger*

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -265,6 +265,12 @@ $(function() {
 		<td valign="top"><code>'optgroup'</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>disabledField</code></td>
+		<td valign="top">The name of the property to disabled option and optgroup.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>'disabled'</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>sortField</code></td>
 		<td valign="top">
 			<p>A single field or an array of fields to sort by. Each item in the array should be an object containing at least a <code>field</code> property. Optionally, <code>direction</code> can be set to <code>'asc'</code> or <code>'desc'</code>. The order of the array defines the sort precedence.</p>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -91,10 +91,29 @@
 					</select>
 				</div>
 				<script>
-				$('#select-beast-disabled').selectize({
-					create: true,
-					sortField: {field: 'text'}
-				});
+					$('#select-beast-disabled').selectize({
+						create: true,
+						sortField: {field: 'text'}
+					});
+				</script>
+			</div>
+
+			<div class="demo">
+				<h2>&lt;select&gt; (&lt;option disabled&gt;)</h2>
+				<div class="control-group">
+					<label for="select-beast-single-disabled">Beast:</label>
+					<select id="select-beast-single-disabled" class="demo-default" placeholder="Select a person...">
+						<option value="">Select a person...</option>
+						<option value="4" disabled>Thomas Edison</option>
+						<option value="1">Nikola</option>
+						<option value="3" selected>Nikola Tesla</option>
+					</select>
+				</div>
+				<script>
+					$('#select-beast-single-disabled').selectize({
+						create: true,
+						sortField: {field: 'text'}
+					});
 				</script>
 			</div>
 

--- a/examples/optgroups.html
+++ b/examples/optgroups.html
@@ -55,9 +55,37 @@
 					</select>
 				</div>
 				<script>
-				$('#select-gear').selectize({
-					sortField: 'text'
-				});
+					$('#select-gear').selectize({
+						sortField: 'text'
+					});
+				</script>
+			</div>
+
+			<div class="demo">
+				<h2>Optgroups (disabled)</h2>
+				<div class="control-group">
+					<label for="select-gear-disabled">Gear:</label>
+					<select id="select-gear-disabled" class="demo-default" multiple placeholder="Select gear...">
+						<option value="">Select gear...</option>
+						<optgroup label="Climbing">
+							<option value="pitons">Pitons</option>
+							<option value="cams">Cams</option>
+							<option value="nuts">Nuts</option>
+							<option value="bolts">Bolts</option>
+							<option value="stoppers">Stoppers</option>
+							<option value="sling">Sling</option>
+						</optgroup>
+						<optgroup label="Skiing" disabled>
+							<option value="skis">Skis</option>
+							<option value="skins">Skins</option>
+							<option value="poles">Poles</option>
+						</optgroup>
+					</select>
+				</div>
+				<script>
+					$('#select-gear-disabled').selectize({
+						sortField: 'text'
+					});
 				</script>
 			</div>
 
@@ -78,9 +106,9 @@
 					</select>
 				</div>
 				<script>
-				$('#select-repeated-options').selectize({
-					sortField: 'text'
-				});
+					$('#select-repeated-options').selectize({
+						sortField: 'text'
+					});
 				</script>
 			</div>
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -30,6 +30,7 @@ Selectize.defaults = {
 	optgroupField: 'optgroup',
 	valueField: 'value',
 	labelField: 'text',
+	disabledField: 'disabled',
 	optgroupLabelField: 'label',
 	optgroupValueField: 'value',
 	lockOptgroupOrder: false,

--- a/src/less/selectize.less
+++ b/src/less/selectize.less
@@ -221,8 +221,15 @@
 			.selectize-border-radius(1px);
 		}
 	}
-	[data-selectable], .optgroup-header {
+	.option, .optgroup-header {
 		padding: @selectize-padding-dropdown-item-y @selectize-padding-dropdown-item-x;
+	}
+	.option, [data-disabled], [data-disabled] [data-selectable].option {
+		cursor: inherit;
+		opacity: 0.5;
+	}
+	[data-selectable].option {
+		opacity: 1;
 	}
 	.optgroup:first-child .optgroup-header {
 		border-top: 0 none;

--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -4,6 +4,7 @@ $.fn.selectize = function(settings_user) {
 	var attr_data            = settings.dataAttr;
 	var field_label          = settings.labelField;
 	var field_value          = settings.valueField;
+	var field_disabled       = settings.disabledField;
 	var field_optgroup       = settings.optgroupField;
 	var field_optgroup_label = settings.optgroupLabelField;
 	var field_optgroup_value = settings.optgroupValueField;
@@ -84,6 +85,7 @@ $.fn.selectize = function(settings_user) {
 			var option             = readData($option) || {};
 			option[field_label]    = option[field_label] || $option.text();
 			option[field_value]    = option[field_value] || value;
+			option[field_disabled] = option[field_disabled] || $option.prop('disabled');
 			option[field_optgroup] = option[field_optgroup] || group;
 
 			optionsMap[value] = option;
@@ -104,6 +106,7 @@ $.fn.selectize = function(settings_user) {
 				optgroup = readData($optgroup) || {};
 				optgroup[field_optgroup_label] = id;
 				optgroup[field_optgroup_value] = id;
+				optgroup[field_disabled] = $optgroup.prop('disabled');
 				settings_element.optgroups.push(optgroup);
 			}
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -167,6 +167,7 @@ $.extend(Selectize.prototype, {
 		if ($input.attr('autocapitalize')) {
 			$control_input.attr('autocapitalize', $input.attr('autocapitalize'));
 		}
+		$control_input[0].type = $input[0].type;
 
 		self.$wrapper          = $wrapper;
 		self.$control          = $control;
@@ -174,6 +175,7 @@ $.extend(Selectize.prototype, {
 		self.$dropdown         = $dropdown;
 		self.$dropdown_content = $dropdown_content;
 
+		$dropdown.on('mouseenter mousedown click', '[data-disabled]>[data-selectable]', function(e) { e.stopImmediatePropagation(); });
 		$dropdown.on('mouseenter', '[data-selectable]', function() { return self.onOptionHover.apply(self, arguments); });
 		$dropdown.on('mousedown click', '[data-selectable]', function() { return self.onOptionSelect.apply(self, arguments); });
 		watchChildEvent($control, 'mousedown', '*:not(input)', function() { return self.onItemSelect.apply(self, arguments); });
@@ -2080,11 +2082,16 @@ $.extend(Selectize.prototype, {
 
 		// add mandatory attributes
 		if (templateName === 'option' || templateName === 'option_create') {
-			html.attr('data-selectable', '');
+			if (!data[self.settings.disabledField]) {
+				html.attr('data-selectable', '');
+			}
 		}
 		else if (templateName === 'optgroup') {
 			id = data[self.settings.optgroupValueField] || '';
 			html.attr('data-group', id);
+			if(data[self.settings.disabledField]) {
+				html.attr('data-disabled', '');
+			}
 		}
 		if (templateName === 'option' || templateName === 'item') {
 			html.attr('data-value', value || '');

--- a/test/events.js
+++ b/test/events.js
@@ -69,6 +69,48 @@ describe('Events', function() {
 					});
 			});
 		});
+
+
+		it('should not be possible to trigger a disabled option', function(done) {
+			var test = setup_test(['<select>',
+				'<option value="a" disabled>Item A</option>',
+				'<option value="b">Item B</option>',
+				'</select>'].join(''), {});
+			var counter = 0;
+			test.$select.on('change', function() { counter++; });
+
+			syn.click(test.selectize.$control).delay(0, function() {
+				syn
+					.click($('[data-value="a"]', test.selectize.$dropdown))
+					.delay(0, function() {
+						expect(counter).to.be.equal(0);
+						done();
+					});
+			});
+		});
+
+		it('should not be possible to trigger a option under a disabled optgroup', function(done) {
+			var test = setup_test(['<select>',
+				'<optgroup label="Group 1">',
+				'<option value="a">Item A</option>',
+				'</optgroup>',
+				'<optgroup label="Group 2" disabled>',
+				'<option value="b">Item B</option>',
+				'<option value="c">Item C</option>',
+				'</optgroup>',
+				'</select>'].join(''), {});
+			var counter = 0;
+			test.$select.on('change', function() { counter++; });
+
+			syn.click(test.selectize.$control).delay(0, function() {
+				syn
+					.click($('[data-value="c"]', test.selectize.$dropdown))
+					.delay(0, function() {
+						expect(counter).to.be.equal(0);
+						done();
+					});
+			});
+		});
 	});
 
 	describe('item_add', function() {

--- a/test/setup.js
+++ b/test/setup.js
@@ -59,6 +59,16 @@
 			});
 		});
 
+		describe('<input type="number">', function() {
+			it('should complete without exceptions', function(done) {
+				var test = setup_test('<input type="number">', {});
+				window.setTimeout(function() {
+					assert.equal(test.selectize.$control_input.attr('type'), 'number');
+					done();
+				}, 0);
+			});
+		});
+
 		describe('<select>', function() {
 			it('should complete without exceptions', function() {
 				var test = setup_test('<select></select>', {});
@@ -66,25 +76,50 @@
 			it('should allow for values optgroups with duplicated options', function() {
 				var test = setup_test(['<select>',
 					'<optgroup label="Group 1">',
-						'<option value="a">Item A</option>',
-						'<option value="b">Item B</option>',
+					'<option value="a">Item A</option>',
+					'<option value="b">Item B</option>',
 					'</optgroup>',
 					'<optgroup label="Group 2">',
-						'<option value="a">Item A</option>',
-						'<option value="b">Item B</option>',
+					'<option value="a">Item A</option>',
+					'<option value="b">Item B</option>',
 					'</optgroup>',
-				'</select>'].join(''), {
+					'</select>'].join(''), {
 					optgroupValueField: 'val',
-					optgroupField: 'grp'
+					optgroupField: 'grp',
+					disabledField: 'dis'
 				});
 				assert.deepEqual(test.selectize.options, {
-					'a': {text: 'Item A', value: 'a', grp: ['Group 1', 'Group 2'], $order: 1},
-					'b': {text: 'Item B', value: 'b', grp: ['Group 1', 'Group 2'], $order: 2}
+					'a': {text: 'Item A', value: 'a', grp: ['Group 1', 'Group 2'], $order: 1, dis: false},
+					'b': {text: 'Item B', value: 'b', grp: ['Group 1', 'Group 2'], $order: 2, dis: false}
 				});
 				assert.deepEqual(test.selectize.optgroups, {
-					'Group 1': {label: 'Group 1', val: 'Group 1', $order: 3},
-					'Group 2': {label: 'Group 2', val: 'Group 2', $order: 4}
+					'Group 1': {label: 'Group 1', val: 'Group 1', $order: 3, dis: false},
+					'Group 2': {label: 'Group 2', val: 'Group 2', $order: 4, dis: false}
+				}, '2');
+			});
+			it('should allow respect disabled flags of option and optgroup', function() {
+				var test = setup_test(['<select>',
+					'<optgroup label="Group 1">',
+					'<option value="a" disabled>Item A</option>',
+					'<option value="b">Item B</option>',
+					'</optgroup>',
+					'<optgroup label="Group 2" disabled>',
+					'<option value="a">Item A</option>',
+					'<option value="b">Item B</option>',
+					'</optgroup>',
+					'</select>'].join(''), {
+					optgroupValueField: 'val',
+					optgroupField: 'grp',
+					disabledField: 'dis'
 				});
+				assert.deepEqual(test.selectize.options, {
+					'a': {text: 'Item A', value: 'a', grp: ['Group 1', 'Group 2'], $order: 1, dis: true},
+					'b': {text: 'Item B', value: 'b', grp: ['Group 1', 'Group 2'], $order: 2, dis: false}
+				});
+				assert.deepEqual(test.selectize.optgroups, {
+					'Group 1': {label: 'Group 1', val: 'Group 1', $order: 3, dis: false},
+					'Group 2': {label: 'Group 2', val: 'Group 2', $order: 4, dis: true}
+				}, '2');
 			});
 			it('should add options in text form (no html entities)', function() {
 				var test = setup_test('<select><option selected value="a">&lt;hi&gt;</option></select>', {});
@@ -160,6 +195,19 @@
 					});
 
 					expect(order_actual).to.eql(order_expected);
+					done();
+				}, 0);
+			});
+			it('should respect option disabled flag', function (done) {
+				var test = setup_test(['<select>',
+					'<option value="a">Item A</option>',
+					'<option value="b" disabled>Item B</option>',
+					'</select>'].join(''), {});
+
+				test.selectize.refreshOptions(true);
+				window.setTimeout(function() {
+					expect(test.selectize.$dropdown.find('.option')).to.has.length(2);
+					expect(test.selectize.$dropdown.find('[data-selectable]')).to.has.length(1);
 					done();
 				}, 0);
 			});


### PR DESCRIPTION
Selectize.js at the moment doesn't respect vanilla HTML `option` and `optgroup` flag `disabled`

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option

This pull request include demo and implementation. I know that tests are missing, I will fix this tomorrow. 

I only want feedback about this and timezone ping pong, before a put more effort in this. 

Have a nice day
David 
