### PR TITLE
Define npm standard commands within package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ BROWSERS=Firefox,Chrome,Safari npm test
 To run Selectize locally:
 
 ```sh
-$ grunt serve
+$ npm start
 ```
 
 You can then run the examples in `http://localhost:8000/examples/`.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,11 @@
     "karma-sauce-launcher": "^0.2.10"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start"
+    "test": "karma start",
+    "build": "make",
+    "prestart": "npm run build",
+    "start": "grunt serve",
+    "grunt": "grunt"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
In reference to https://github.com/selectize/selectize.js/pull/1131
I split my changes within build chain from the other pull request and move it in this one
- start local environment with `npm start`
- build default version with `npm build`
- run test suite with `npm test`, already existed command but improve because you don't need full relative path
- grunt npm script alias, this has the benefit you don't need a global installed grunt, `npm run grunt -- --plugins=remove_button,restore_on_backspace` will do the same like `grunt --plugin=remove_button,restore_on_backspace`

This are only aliases and are only in interest for new developers follow the npm script philosophy of unified build commands
