### PR TITLE
Feature request: Override control input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+*  Feature to allow override input control type for e.g. keyboard suggestion on touch devices (#1135)
+
+   *@zeitiger*
+   
 *  Output friendly error message when Microplguin is missing (#1137).
    Special thanks to @styxxx for proposing the improvement.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -289,6 +289,12 @@ $(function() {
 		<td valign="top"><code>'and'</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>searchInputType</td>
+		<td valign="top">Allow to override input control type. Useful for touch devices to make suggestion which keyboard should be used.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>'text'</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>lockOptgroupOrder</td>
 		<td valign="top">If truthy, Selectize will make all optgroups be in the same order as they were added (by the `$order` property). Otherwise, it will order based on the score of the results in each.</td>
 		<td valign="top"><code>boolean</code></td>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -27,13 +27,29 @@
 					<input type="text" id="input-tags" class="demo-default" value="awesome,neat">
 				</div>
 				<script>
-				$('#input-tags').selectize({
-					persist: false,
-					createOnBlur: true,
-					create: true
-				});
+					$('#input-tags').selectize({
+						persist: false,
+						createOnBlur: true,
+						create: true
+					});
 				</script>
 			</div>
+			<div class="demo">
+				<h2>&lt;input type="text"&gt; (custom input type)</h2>
+				<div class="control-group">
+					<label for="input-tags">Number tags:</label>
+					<input type="text" id="input-number-tags" class="demo-default" value="5,23,42,1337">
+				</div>
+				<script>
+					$('#input-number-tags').selectize({
+						persist: false,
+						createOnBlur: true,
+						create: true,
+						searchInputType: 'tel'
+					});
+				</script>
+			</div>
+
 
 			<div class="demo">
 				<h2>&lt;select&gt;</h2>
@@ -48,14 +64,14 @@
 					</select>
 				</div>
 				<script>
-				$('#select-beast').selectize({
-					create: true,
-					sortField: {
-						field: 'text',
-						direction: 'asc'
-					},
-					dropdownParent: 'body'
-				});
+					$('#select-beast').selectize({
+						create: true,
+						sortField: {
+							field: 'text',
+							direction: 'asc'
+						},
+						dropdownParent: 'body'
+					});
 				</script>
 			</div>
 
@@ -485,6 +501,34 @@
 				$('#select-state-disabled').selectize({
 					maxItems: 3
 				});
+				</script>
+			</div>
+			<div class="demo">
+				<h2>&lt;select&gt; (custom search input type)</h2>
+				<div class="control-group">
+					<label for="select-country-tel-code">Telephone country code:</label>
+					<select id="select-country-tel-code" class="demo-default" placeholder="Enter a country code e.g. +44">
+						<option value="">Select a country...</option>
+						<option value="+1">USA/Canada</option>
+						<option value="+27">South Africa</option>
+						<option value="+33">France</option>
+						<option value="+43">Austria</option>
+						<option value="+44">United Kingdom</option>
+						<option value="+49">Germany</option>
+						<option value="+55">Brazil</option>
+						<option value="+61">Australia</option>
+						<option value="+7">Russia</option>
+						<option value="+81">Japan</option>
+						<option value="+86">China</option>
+						<option value="+91">India</option>
+					</select>
+				</div>
+				<script>
+					$('#select-country-tel-code').selectize({
+						searchField: ['value'],
+						searchInputType: 'tel',
+						dropdownParent: 'body'
+					});
 				</script>
 			</div>
 		</div>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -37,6 +37,7 @@ Selectize.defaults = {
 	sortField: '$order',
 	searchField: ['text'],
 	searchConjunction: 'and',
+	searchInputType : 'text',
 
 	mode: null,
 	wrapperClass: 'selectize-control',

--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -15,6 +15,8 @@ $.fn.selectize = function(settings_user) {
 	 * @param {object} settings_element
 	 */
 	var init_textbox = function($input, settings_element) {
+		settings_element.searchInputType = $input.prop('type');
+
 		var i, n, values, option;
 
 		var data_raw = $input.attr(attr_data);

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -133,7 +133,8 @@ $.extend(Selectize.prototype, {
 
 		$wrapper          = $('<div>').addClass(settings.wrapperClass).addClass(classes).addClass(inputMode);
 		$control          = $('<div>').addClass(settings.inputClass).addClass('items').appendTo($wrapper);
-		$control_input    = $('<input type="text" autocomplete="off" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
+		$control_input    = $('<input type="' + settings.searchInputType + '" autocomplete="off" />')
+			.appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 		$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 		$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
 		$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);

--- a/test/setup.js
+++ b/test/setup.js
@@ -17,6 +17,18 @@
 			it('should complete without exceptions', function() {
 				var test = setup_test('<input type="text">', {});
 			});
+			it('should customize input type for control input via user setting', function() {
+				var test = setup_test('<input type="text">', {searchInputType: 'number'});
+				assert.equal(test.selectize.$control_input.prop('type'), 'number');
+			});
+			it('should customize input type for control input via input setting', function() {
+				var test = setup_test('<input type="tel">');
+				assert.equal(test.selectize.$control_input.prop('type'), 'tel');
+			});
+			it('should customize input type for control input user setting > input setting', function() {
+				var test = setup_test('<input type="tel">', {searchInputType: 'number'});
+				assert.equal(test.selectize.$control_input.prop('type'), 'number');
+			});
 			it('should populate items,options from "dataAttr" if available', function() {
 				var data = [{val: 'a', lbl: 'Hello'}, {val: 'b', lbl: 'World'}];
 				var test = setup_test('<input type="text" value="c,d,e" data-hydrate="' + JSON.stringify(data).replace(/"/g,'&quot;') + '">', {
@@ -62,6 +74,10 @@
 		describe('<select>', function() {
 			it('should complete without exceptions', function() {
 				var test = setup_test('<select></select>', {});
+			});
+			it('should customize input type for control input', function() {
+				var test = setup_test('<select></select>', {searchInputType: 'number'});
+				assert.equal(test.selectize.$control_input.prop('type'), 'number');
 			});
 			it('should allow for values optgroups with duplicated options', function() {
 				var test = setup_test(['<select>',


### PR DESCRIPTION
Currently the control input is a simple text input. 

Sometimes its quite helpful override the input type for touch devices e.g. for input of numeric data is a `<input type="tel">` better option for a small smartphone.

![image1](https://cloud.githubusercontent.com/assets/656302/17622131/c4b7a214-6098-11e6-8df6-0424e71a5ad7.PNG)

This pull request include 
- 2 test cases (select and input)
- documentation for a new setting
- 2 new demo cases with input-tag-with-dialpad and select with search country telephone codes
