### PR TITLE
Fixed jQuery not found error

### DIFF
--- a/src/contrib/highlight.js
+++ b/src/contrib/highlight.js
@@ -42,7 +42,7 @@ var highlight = function($element, pattern) {
  * removeHighlight fn copied from highlight v5 and
  * edited to remove with() and pass js strict mode
  */
-jQuery.fn.removeHighlight = function() {
+$.fn.removeHighlight = function() {
 	return this.find("span.highlight").each(function() {
 		this.parentNode.firstChild.nodeName;
 		var parent = this.parentNode;


### PR DESCRIPTION
Replaced reference to window.jQuery in removeHighlight plugin with $
