### PR TITLE
Improve IE11 fix not to throw errors when element cannot be focused

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -646,7 +646,7 @@ $.extend(Selectize.prototype, {
 			self.refreshState();
 
 			// IE11 bug: element still marked as active
-			dest && dest.focus();
+			dest && dest.focus && dest.focus();
 
 			self.ignoreFocus = false;
 			self.trigger('blur');


### PR DESCRIPTION
Sometimes element passed as second argument to onBlur handler
doesn't have focus method, i.e. inline svg element in IE
