### PR TITLE
Remove Single don't add close arrow

### DIFF
--- a/src/plugins/remove_button/plugin.js
+++ b/src/plugins/remove_button/plugin.js
@@ -37,7 +37,8 @@ Selectize.define('remove_button', function(options) {
 			 * @return {string}
 			 */
 			var append = function(html_container, html_element) {
-				return html_container + html_element;
+				return $('<span>').append(html_container)
+					.append(html_element);
 			};
 
 			thisRef.setup = (function() {

--- a/src/plugins/remove_button/plugin.less
+++ b/src/plugins/remove_button/plugin.less
@@ -36,8 +36,8 @@
 	}
 	.remove-single {
 		position: absolute;
-		right: 28px;
-		top: 6px;
+		right: 0;
+		top: 0;
 		font-size: 23px;
 	}
 }


### PR DESCRIPTION
The arrow to remove an item on single select is always missing on current version.
The RemoveSingle plugins return 2 html elements (the initial one and the clsoe arrow) and the render only the first one 

``` js
    render: function(templateName, data) {
            // ...
            html = $(self.settings.render[templateName].apply(this, [data, escape_html]));
            // ...

            return html[0];
        },
```

I also fix the layout that is broken (the arrow was over the text) for all themes
