### PR TITLE
Fix scrolling on iOS (iPad/iPhone)

### DIFF
--- a/src/less/selectize.less
+++ b/src/less/selectize.less
@@ -248,6 +248,7 @@
 	overflow-y: auto;
 	overflow-x: hidden;
 	max-height: @selectize-max-height-dropdown;
+	-webkit-overflow-scrolling: touch;
 }
 
 .selectize-control.single .selectize-input {


### PR DESCRIPTION
Scroll behaviour is currently really bad on iOS mobile devices. There are no scroll bars and scrolling has no momentum (i.e. it immediately stops when you remove your finger)

This can be fixed by simply adding the webkit custom css property to `touch`.
See also:
https://www.johanbrook.com/writings/native-style-momentum-scrolling-to-arrive-in-ios-5/
https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling
