### PR TITLE
Support for other input types

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -12,7 +12,7 @@ Selectize.defaults = {
 	createOnBlur: false,
 	createFilter: null,
 	highlight: true,
-	inputType: 'text',
+	inputType: null,
 	openOnFocus: true,
 	maxOptions: 1000,
 	maxItems: null,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -12,6 +12,7 @@ Selectize.defaults = {
 	createOnBlur: false,
 	createFilter: null,
 	highlight: true,
+	inputType: 'text',
 	openOnFocus: true,
 	maxOptions: 1000,
 	maxItems: null,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -106,7 +106,7 @@ $.extend(Selectize.prototype, {
         buildControlInput: function(control) {
             var self = this;
 
-            var $control_input = $('<input type="'+self.settings.inputType+'" name="_selectize_q" autocomplete="off" />')
+            var $control_input = $('<input type="'+(self.settings.inputType || self.$input.attr('type'))+'" name="_selectize_q" autocomplete="off" />')
                 .appendTo(control).attr('tabindex', self.$input.is(':disabled') ? '-1' : self.tabIndex);
 
             var inputId;


### PR DESCRIPTION
Adds ability to specify other input types than text. It is also possible to use changeInputType, to change it after creation. However there are limitation on which types are supported. Only types with selection support can be used (https://html.spec.whatwg.org/multipage/forms.html#do-not-apply). #149
