### PR TITLE
Fix special char issue in firefox

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -253,7 +253,7 @@ var measureString = function(str, $parent) {
 	]);
 
 	var width = $test.width();
-	$test.remove();
+	setTimeout(function() { $test.remove(); }, 0);
 
 	return width;
 };


### PR DESCRIPTION
I've noticed that in Firefox with newer versions of jQuery (version 2 or 3), that special characters like `@`, `-` or even umlauts like `ä` won't be inserted into the select box.

I've tracked down the bug to the `measureString` function, I don't know what is _really_ causing the bug, but if I remove the `$test` element asynchronously, it seems to be working in Firefox again.

Might be related to #809.