### PR TITLE
remove highlight even when query is empty

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1123,10 +1123,12 @@ $.extend(Selectize.prototype, {
 		$dropdown_content.html(html);
 
 		// highlight matching terms inline
-		if (self.settings.highlight && results.query.length && results.tokens.length) {
+		if (self.settings.highlight) {
 			$dropdown_content.removeHighlight();
-			for (i = 0, n = results.tokens.length; i < n; i++) {
-				highlight($dropdown_content, results.tokens[i].regex);
+			if (results.query.length && results.tokens.length) {
+				for (i = 0, n = results.tokens.length; i < n; i++) {
+					highlight($dropdown_content, results.tokens[i].regex);
+				}
 			}
 		}
 


### PR DESCRIPTION
This simple change fixes a bug where, after deleting the search text, the highlighting for the last search value is not removed from the items in the dropdown list. I do not have the environment set up to run tests, so no tests have been run, although it is a very simple change and it appears to work as expected in my use case.