### PR TITLE
Change to `Optgroup` support boolean typo in optgroupField

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -946,7 +946,7 @@ $.extend(Selectize.prototype, {
 		for (i = 0; i < n; i++) {
 			option      = self.options[results.items[i].id];
 			option_html = self.render('option', option);
-			optgroup    = option[self.settings.optgroupField] || '';
+			optgroup    = hash_key(option[self.settings.optgroupField]);
 			optgroups   = $.isArray(optgroup) ? optgroup : [optgroup];
 
 			for (j = 0, k = optgroups && optgroups.length; j < k; j++) {


### PR DESCRIPTION
When optgroupField is boolean, it's not work because `registerOption` and `refreshOptions` functions are using differents ways to validate value for optgroup. The solution that I found was to use the `hash_key` existing function on refreshOptions when get optgroup value.