### PR TITLE
Fix tab key regression introduced by touch handling #1164

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1752,7 +1752,9 @@ $.extend(Selectize.prototype, {
 
 		if (self.settings.mode === 'single' && self.items.length) {
 			self.hideInput();
-			self.$control_input.blur(); // close keyboard on iOS
+			setTimeout(function() {
+				self.$control_input.blur(); // close keyboard on iOS
+			});
 		}
 
 		self.isOpen = false;


### PR DESCRIPTION
Unfortunately [You Can't Detect A Touchscreen](http://www.stucox.com/blog/you-cant-detect-a-touchscreen/) but we can escape the call stack (using ``setTimeout``) before bluring. That allows the default tab key action to take place first.

I've tested it in Firefox and Chrome (Desktop and Android) -- I was able to reproduce #1127 on Android too, but I don't have an iOS device at hand...