### PR TITLE
Rename model properties

### DIFF
--- a/examples/api.html
+++ b/examples/api.html
@@ -61,8 +61,8 @@
 
 				$('#button-addoption').on('click', function() {
 					control.addOption({
-						value: 4,
-						text: 'Something New',
+						id: 4,
+						title: 'Something New',
 						url: 'http://google.com'
 					});
 				});


### PR DESCRIPTION
Changes at examples/api.html

At selectize initialization we have ('id' and 'title' properties names):
`options: [	{id: 1, title: 'Spectrometer', url: 'http://en.wikipedia.org/wiki/Spectrometers'},......

At AddOption handler must be same viewModel, but properties names differ:
`control.addOption({	value: 4,	text: 'Something New',......`

Pull request rename properties at AddOption handler as they are at initialization. Otherwise button 'AddOption()' does not work