### PR TITLE
Allow the dropdown to reopen on click (closeAfterSelect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
 
+*  Allow the dropdown to reopen on click if it is closed without losing focus
+   by closeAfterSelect: true
+   
+   *@fishpercolator*
+
 *  New feature: allow to disable single options or complete optgroups
 
    *@zeitiger*

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -362,7 +362,9 @@ $.extend(Selectize.prototype, {
 
 		// necessary for mobile webkit devices (manual focus triggering
 		// is ignored unless invoked within a click event)
-		if (!self.isFocused) {
+    // also necessary to reopen a dropdown that has been closed by
+    // closeAfterSelect
+		if (!self.isFocused || !self.isOpen) {
 			self.focus();
 			e.preventDefault();
 		}

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -41,6 +41,23 @@
 				});
 			});
 		});
+    
+    it('should reopen dropdown if clicked after being closed by closeAfterSelect: true', function(done) {
+      var test = setup_test('<select multiple>' +
+				'<option value="a">A</option>' +
+				'<option value="b">B</option>' +
+				'</select>', {closeAfterSelect: true});
+
+			click(test.selectize.$control, function() {
+				click($('[data-value=a]', test.selectize.$dropdown_content), function() {
+          click(test.selectize.$control, function () {
+  					expect(test.selectize.isOpen).to.be.equal(true);
+  					expect(test.selectize.isFocused).to.be.equal(true);
+  					done();
+          });
+				});
+			});
+    });
 
 		it('should close and blur dropdown after selection made if closeAfterSelect: true and in single mode' , function(done) {
 			var test = setup_test('<select>' +


### PR DESCRIPTION
When `closeAfterSelect` is true, the selectize doesn't lose focus, which means it doesn't reopen when the user clicks it again unless they take the focus away first. This feels unnatural to me (because it's different from how a `<select>` behaves).

I've made this little change that allows the `onClick()` handler to run if the dropdown has been closed by `closeAfterSelect`.

Let me know if you'd rather I made this optional, but it seems pretty natural to me and doesn't break any of the existing tests.