### PR TITLE
Use JQuery.detach on removeItem so custom data attributes are retained

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1522,7 +1522,7 @@ $.extend(Selectize.prototype, {
 		i = self.items.indexOf(value);
 
 		if (i !== -1) {
-			$item.remove();
+			$item.detach();
 			if ($item.hasClass('active')) {
 				idx = self.$activeItems.indexOf($item[0]);
 				self.$activeItems.splice(idx, 1);

--- a/test/events.js
+++ b/test/events.js
@@ -149,6 +149,15 @@ describe('Events', function() {
 			});
 			test.selectize.removeItem('b');
 		});
+		it('should not lose custom data attributes', function(done) {
+			var settings = {render: {item: function(item, escape) {return $('<div/>').data('test-data', 1);} }};
+			var test = setup_test('<select multiple><option value="a" selected></option><option value="b" selected></option><option value="c"></option></select>', settings);
+			test.selectize.on('item_remove', function(value, $item) {
+				expect($($item).data('test-data')).to.be.equal(1);
+				done();
+			});
+			test.selectize.removeItem('b');
+		});
 	});
 
 	describe('clear', function() {


### PR DESCRIPTION
I'm using a custom Item renderer with some custom data attribute fields. When .remove is used, JQuery removes the data-* and event handlers. Since selectize caches the rendered item it doesn't get created each time so the data-* attributes and even handlers are lost. To prevent his situation I changed the .remove() to .detach(). I also added a test to check for data-* attribute retention. 
