### PR TITLE
Respect data attributes on a specific element as options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
 
+*  New feature: allow `data-` attributes to override options
+
+   *@ersatzryan*
+
 *  New feature: allow to disable single options or complete optgroups
 
    *@zeitiger*

--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -153,7 +153,7 @@ $.fn.selectize = function(settings_user) {
 			init_textbox($input, settings_element);
 		}
 
-		instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, settings_user));
+		instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, settings_user, $input.data()));
 	});
 };
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -44,6 +44,10 @@
 					var test = setup_test('<input type="text" value="a,b">', {delimiter: ','});
 					expect(test.selectize.getValue()).to.be.equal('a,b');
 				});
+				it('should respect data attribute options', function() {
+					var test = setup_test('<input type="text" value="a,b" data-delimiter=":">', {delimiter: ','});
+					expect(test.selectize.getValue()).to.be.equal('a:b');
+				});
 			});
 			describe('<input type="text" attributes>', function() {
 				it('should propagate original input attributes to the generated input', function() {


### PR DESCRIPTION
I wasn't really sure where to put tests for this, so I chose a test that was using an option and then asserted that a different data attribute would take precedence.

Let me know if you would prefer something else.