### PR TITLE
Issue 479 - add touchstart in order to catch touches as well as clicks when adding custom items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
 
+*  Bugfix: add touchstart in order to catch touches as well as clicks when adding custom items
+
+   *@danielgehr*
+
 *  New feature: allow to disable single options or complete optgroups
 
    *@zeitiger*

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -188,7 +188,7 @@ $.extend(Selectize.prototype, {
 
 		$dropdown.on('mouseenter mousedown click', '[data-disabled]>[data-selectable]', function(e) { e.stopImmediatePropagation(); });
 		$dropdown.on('mouseenter', '[data-selectable]', function() { return self.onOptionHover.apply(self, arguments); });
-		$dropdown.on('mousedown click', '[data-selectable]', function() { return self.onOptionSelect.apply(self, arguments); });
+		$dropdown.on('mousedown click touchstart', '[data-selectable]', function() { return self.onOptionSelect.apply(self, arguments); });
 		watchChildEvent($control, 'mousedown', '*:not(input)', function() { return self.onItemSelect.apply(self, arguments); });
 		autoGrow($control_input);
 


### PR DESCRIPTION
We faced the same problem with selectize on iOS as _adamgins_ describes in this issue:
https://github.com/selectize/selectize.js/issues/479

Basically we where not able to add new custom items to the selectize by clicking the _"add-option"_. It worked fine when running on a desktop machine using the mouse or when adding the option on an iOS device by hitting _enter_ on the keyboard. Just clicking the _"add-option"_ on a touch device didn't work.

Seemed like somewhere the touch got lost while the click was respected.
We where able to solve that problem by adding the `touchstart` event to the selectize.