### PR TITLE
Replaces newlines in `table` with <br> 

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,12 +37,12 @@ $(function() {
 		<td valign="top">
 			An array of the initial options available to select; array
 			of objects.<br>
-      <br>
+			<br>
 			By default this is populated from the original input
 			element.  If your element is a &lt;select&gt; with
 			&lt;option&gt;s specified this property gets populated
 			automatically.<br>
-      <br>
+			<br>
 			Setting this property is convenient if you have your data as
 			an array and want to automatically generate the
 			&lt;option&gt;s.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,13 +36,13 @@ $(function() {
 		<td valign="top"><code>options</code></td>
 		<td valign="top">
 			An array of the initial options available to select; array
-			of objects.
-
+			of objects.<br>
+      <br>
 			By default this is populated from the original input
 			element.  If your element is a &lt;select&gt; with
 			&lt;option&gt;s specified this property gets populated
-			automatically.
-
+			automatically.<br>
+      <br>
 			Setting this property is convenient if you have your data as
 			an array and want to automatically generate the
 			&lt;option&gt;s.
@@ -197,19 +197,15 @@ $(function() {
 		<td valign="top"><code>boolean</code></td>
 		<td valign="top"><code>true</code></td>
 	</tr>
-
-
 	<tr>
 		<th valign="top" colspan="4" align="left"><a href="#data_searching" name="data_searching">Data / Searching</a></th>
 	</tr>
-
 	<tr>
 		<th valign="top" align="left">Setting</th>
 		<th valign="top" align="left">Description</th>
 		<th valign="top" align="left">Type</th>
 		<th valign="top" align="left">Default</th>
 	</tr>
-
 	<tr>
 		<td valign="top"><code>options</code></td>
 		<td valign="top">See above</td>
@@ -274,9 +270,7 @@ $(function() {
 		<td valign="top"><code>sortField</code></td>
 		<td valign="top">
 			<p>A single field or an array of fields to sort by. Each item in the array should be an object containing at least a <code>field</code> property. Optionally, <code>direction</code> can be set to <code>'asc'</code> or <code>'desc'</code>. The order of the array defines the sort precedence.</p>
-
 			<p>Unless present, a special `$score` field will be automatically added to the beginning of the sort list. This will make results sorted primarily by match quality (descending).</p>
-
 			<p>You can override the `$score` function. For more information, see the <a href="https://github.com/brianreavis/sifter.js#sifterjs">sifter documentation</a>.</p>
 		</td>
 		<td valign="top"><code>string|array</code></td>
@@ -419,8 +413,8 @@ $(function() {
 		<td valign="top">
 			Custom rendering functions. Each function should accept two
 			arguments: <code>data</code> and <code>escape</code> and return HTML (string
-			or DOM element) with a single root element.
-
+			or DOM element) with a single root element.<br>
+			<br>
 			The <code>escape</code> argument is a function that takes a string and
 			escapes all special HTML characters.
 			This is very important to use to prevent XSS vulnerabilities.


### PR DESCRIPTION
Markdown seems to freak out over usage of newlines in `<tables>`.