### PR TITLE
Adding ability to use load to init opt groups

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -740,11 +740,17 @@ $.extend(Selectize.prototype, {
 		var $wrapper = self.$wrapper.addClass(self.settings.loadingClass);
 
 		self.loading++;
-		fn.apply(self, [function(results) {
+		fn.apply(self, [function(results, groups) {
 			self.loading = Math.max(self.loading - 1, 0);
 			if (results && results.length) {
 				self.addOption(results);
 				self.refreshOptions(self.isFocused && !self.isInputHidden);
+			}
+			if (groups && groups.length) {
+				groups.forEach(function (group) {
+					var id = group[self.settings.optgroupValueField];
+					self.addOptionGroup(id, group);
+				});
 			}
 			if (!self.loading) {
 				$wrapper.removeClass(self.settings.loadingClass);


### PR DESCRIPTION
I noticed the ability to init the list from a async source was missing the ability to also init groups, so I added what I thought was needed to get this working. It utilizes the optgroupValueField to figure out the Id to use with the addOptionGroup method and iterates through the list of groups to add them.

I looked for any examples of tests for the load function but didn't find any. I am going to take a look at adding a test once I figured out how to use this testing pattern with the function but I wanted to get this pull request open so its at least on the board.