### PR TITLE
Performance improvements

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1502,7 +1502,10 @@ $.extend(Selectize.prototype, {
 
 				self.updatePlaceholder();
 				self.trigger('item_add', value, $item);
-				self.updateOriginalInput({silent: silent});
+
+				if (!self.isPending) {
+					self.updateOriginalInput({silent: silent});
+				}
 			}
 		});
 	},

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1496,7 +1496,7 @@ $.extend(Selectize.prototype, {
 				// hide the menu if the maximum number of items have been selected or no options are left
 				if (!$options.length || self.isFull()) {
 					self.close();
-				} else {
+				} else if (!self.isPending) {
 					self.positionDropdown();
 				}
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1439,11 +1439,23 @@ $.extend(Selectize.prototype, {
 	 * @param {boolean} silent
 	 */
 	addItems: function(values, silent) {
+		this.buffer = document.createDocumentFragment();
+
+		var childNodes = this.$control[0].childNodes;
+		for (var i = 0; i < childNodes.length; i++) {
+			this.buffer.appendChild(childNodes[i]);
+		}
+
 		var items = $.isArray(values) ? values : [values];
 		for (var i = 0, n = items.length; i < n; i++) {
 			this.isPending = (i < n - 1);
 			this.addItem(items[i], silent);
 		}
+
+		var control = this.$control[0];
+		control.insertBefore(this.buffer, control.firstChild);
+
+		this.buffer = null;
 	},
 
 	/**
@@ -1819,11 +1831,15 @@ $.extend(Selectize.prototype, {
 	 */
 	insertAtCaret: function($el) {
 		var caret = Math.min(this.caretPos, this.items.length);
+		var el = $el[0];
+		var target = this.buffer || this.$control[0];
+
 		if (caret === 0) {
-			this.$control.prepend($el);
+			target.insertBefore(el, target.firstChild);
 		} else {
-			$(this.$control[0].childNodes[caret]).before($el);
+			target.insertBefore(el, target.childNodes[caret]);
 		}
+
 		this.setCaret(caret + 1);
 	},
 


### PR DESCRIPTION
These are some performance improvements we've made over last couple of years for the Mavenlink application's use of selectize. We had intended to port these over in to a PR some time ago but got swamped. That said, I suppose they've been more battle tested as a result. Here are the relevant changes:

* Use document fragment to improve performance when adding multiple items d5785f0
* Only position dropdown once when adding multiple items 8f46e77
* Only update original input once when adding multiple items 1782fb4e