### PR TITLE
Proper way to set/unset required attributes: fix for MS Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
+* Fix issues with required attribute in MS Edge (#1320)
+
+    *@TomOne*
 
 *  New feature: allow to disable single options or complete optgroups
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1660,8 +1660,12 @@ $.extend(Selectize.prototype, {
 		var invalid = !this.items.length;
 
 		this.isInvalid = invalid;
-		this.$control_input.prop('required', invalid);
-		this.$input.prop('required', !invalid);
+		invalid
+			? this.$control_input.attr('required', true)
+			: this.$control_input.removeAttr('required');
+		!invalid
+			? this.$input.attr('required', true)
+			: this.$input.removeAttr('required');
 	},
 
 	/**


### PR DESCRIPTION
Using .prop('required', true) or .prop('required', false) is non-standard and doesn’t work in all browsers, such as Microsoft Edge. This replaces the occurrences with the proper `attr`/`removeAttr` methods.

Now https://github.com/selectize/selectize.js/blob/master/examples/required.html also works with MS Edge.

Fixes #1319.