### PR TITLE
fixed wrong string width calculation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -301,11 +301,7 @@ var autoGrow = function($input) {
 					value = value.substring(0, selection.start) + value.substring(selection.start + 1);
 				}
 			} else if (printable) {
-				shift = e.shiftKey;
-				character = String.fromCharCode(e.keyCode);
-				if (shift) character = character.toUpperCase();
-				else character = character.toLowerCase();
-				value += character;
+				value += e.key;
 			}
 		}
 


### PR DESCRIPTION
Fixed bug with string width calculation.
According to [issue #1336: text jumps when any language with non-English letters used](https://github.com/selectize/selectize.js/issues/1336)