### PR TITLE
Updated rotten tomatoes API URL to be protocol agnostic

### DIFF
--- a/examples/movies.html
+++ b/examples/movies.html
@@ -139,7 +139,7 @@
 					load: function(query, callback) {
 						if (!query.length) return callback();
 						$.ajax({
-							url: 'http://api.rottentomatoes.com/api/public/v1.0/movies.json',
+							url: '//api.rottentomatoes.com/api/public/v1.0/movies.json',
 							type: 'GET',
 							dataType: 'jsonp',
 							data: {


### PR DESCRIPTION
Issue: when the selectize homepage is loaded over HTTPS, API requests to rotten tomatoes aren't triggered since the URL is hard-coded to HTTP. 

Fix: made the API URL protocol agnostic.
 
![screenshot from 2018-01-05 12-44-34](https://user-images.githubusercontent.com/2044493/34592181-66df2ffc-f216-11e7-9f9d-f89372b32545.png)
