### PR TITLE
Autofill disable possibility

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -133,7 +133,7 @@ $.extend(Selectize.prototype, {
 
 		$wrapper          = $('<div>').addClass(settings.wrapperClass).addClass(classes).addClass(inputMode);
 		$control          = $('<div>').addClass(settings.inputClass).addClass('items').appendTo($wrapper);
-		$control_input    = $('<input type="text" autocomplete="off" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
+		$control_input    = $('<input type="text" />').appendTo($control).attr('autocomplete', ($input.attr('autocomplete') == 'new-password') ? 'new-password' : 'off').attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 		$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 		$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
 		$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);


### PR DESCRIPTION
The only option to disable autofill in modern browsers is to provide a possibility to set autocomplete="new-password"