### PR TITLE
Updating the default option data.

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -2135,6 +2135,14 @@ $.extend(Selectize.prototype, {
 		}
 		if (templateName === 'option' || templateName === 'item') {
 			html.attr('data-value', value || '');
+                        
+                        // Adding the item html data to the created one.
+                        label = data[self.settings.labelField]
+
+                        if(label && value)
+                        {
+                            html.html(label)
+                        }
 		}
 
 		// update cache


### PR DESCRIPTION
When i was about to set default data for every select in my page, "Selectize" created the items empty but with the value instead; the problem was that the html of the default select's option was not correctly set inside the created item by Selectize's mechanism so thats why I initialize the every item with the default html inside the current processed option's html.