### PR TITLE
Fix module detection

### DIFF
--- a/src/.wrapper.js
+++ b/src/.wrapper.js
@@ -20,7 +20,7 @@
 (function(root, factory) {
 	if (typeof define === 'function' && define.amd) {
 		define(['jquery','sifter','microplugin'], factory);
-	} else if (typeof exports === 'object') {
+	} else if (typeof module === 'object' && typeof module.exports === 'object') {
 		module.exports = factory(require('jquery'), require('sifter'), require('microplugin'));
 	} else {
 		root.Selectize = factory(root.jQuery, root.Sifter, root.MicroPlugin);


### PR DESCRIPTION
The previous detection only checked for a variable named `exports`, and then actually accessed `module.exports`. So if you had code like this

```js
var exports = {};
```

and then later included the `selectize.js` file, you would get `ReferenceError: module is undefined`