### PR TITLE
Added dropdown item activation events

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -340,7 +340,9 @@ $.extend(Selectize.prototype, {
 			'type'            : 'onType',
 			'load'            : 'onLoad',
 			'focus'           : 'onFocus',
-			'blur'            : 'onBlur'
+			'blur'            : 'onBlur',
+			'dropdown_item_activate'        : 'onDropdownItemActivate',
+			'dropdown_item_deactivate'      : 'onDropdownItemDeactivate'
 		};
 
 		for (key in callbacks) {
@@ -880,13 +882,17 @@ $.extend(Selectize.prototype, {
 		var scroll_top, scroll_bottom;
 		var self = this;
 
-		if (self.$activeOption) self.$activeOption.removeClass('active');
+		if (self.$activeOption) {
+			self.$activeOption.removeClass('active');
+			self.trigger('dropdown_item_deactivate', self.$activeOption.attr('data-value'));
+		}
 		self.$activeOption = null;
 
 		$option = $($option);
 		if (!$option.length) return;
 
 		self.$activeOption = $option.addClass('active');
+		if (self.isOpen) self.trigger('dropdown_item_activate', self.$activeOption.attr('data-value'));
 
 		if (scroll || !isset(scroll)) {
 


### PR DESCRIPTION
I use these for the following university scheduling project:
https://cheesefork.cf/
As you can see, when an item is activated in the dropdown, it's also previewed in the calendar.
I'm sure that it can have other uses.