### PR TITLE
Enhancement - dropdownParent

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -173,7 +173,7 @@ $(function() {
 	</tr>
 	<tr>
 		<td valign="top"><code>dropdownParent</code></td>
-		<td valign="top">The element the dropdown menu is appended to. This should be <code>'body'</code> or <code>null</code>. If null, the dropdown will be appended as a child of the Selectize control.</td>
+		<td valign="top">The element the dropdown menu is appended to. If null, the dropdown will be appended as a child of the Selectize control.</td>
 		<td valign="top"><code>string</code></td>
 		<td valign="top"><code>null</code></td>
 	</tr>

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1803,17 +1803,16 @@ $.extend(Selectize.prototype, {
 	 * Calculates and applies the appropriate
 	 * position of the dropdown.
 	 */
-	positionDropdown: function() {
-		var $control = this.$control;
-		var offset = this.settings.dropdownParent === 'body' ? $control.offset() : $control.position();
-		offset.top += $control.outerHeight(true);
+	 positionDropdown: function() {
+		 var $control = this.$control;
 
-		this.$dropdown.css({
-			width : $control[0].getBoundingClientRect().width,
-			top   : offset.top,
-			left  : offset.left
-		});
-	},
+		 this.$dropdown.offset({
+			 top:  $control.offset().top + $control[0].offsetHeight,
+			 left: $control.offset().left,
+		 }).css({
+			 width : $control[0].getBoundingClientRect().width,
+		 });
+	 },
 
 	/**
 	 * Resets / clears all selected items


### PR DESCRIPTION
#### Modified
- dropdownParent 
  - before: usable only `'body'` or `null`
  - I modified: usable any element e.g. `'.container'` , `'.modal'` and so on...


#### My changed reason
It can't hide selectize with modal simply.
https://github.com/selectize/selectize.js/issues/47

