### PR TITLE
Fix "Invalid argument" in IE11

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -179,7 +179,7 @@ $.extend(Selectize.prototype, {
 		if ($input.attr('autocapitalize')) {
 			$control_input.attr('autocapitalize', $input.attr('autocapitalize'));
 		}
-		$control_input[0].type = $input[0].type;
+		$control_input[0].type = $input[0].type || "text";
 
 		self.$wrapper          = $wrapper;
 		self.$control          = $control;


### PR DESCRIPTION
Fixes #1453

The problem occurs when the element is not a 'select'

Example:

    $('div.mySelect').selectize(options);