### PR TITLE
Code changes for issue #110 "Disable text input on a vanilla select"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 <!-- Feel free to put either your handle and/or full name, according to
      your privacy needs -->
 
+## v0.12.7 · 08 January 2019
+
+*  Added option to disable (hide) the text search functionality, with option "hideSearch"
+
+   *@paulklinkenberg*
+
+
+## v0.12.6 · 12 July 2018
+
+*  No changes, just a version number update
+
+
 ## v0.12.4, v0.12.5 · 27 June 2018
 
 *  Allow the dropdown to reopen on click if it is closed without losing focus

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -275,19 +275,25 @@ $(function() {
 		<td valign="top"><code>'$order'</code></td>
 	</tr>
 	<tr>
-		<td valign="top"><code>searchField</td>
+		<td valign="top"><code>searchField</code></td>
 		<td valign="top">An array of property names to analyze when filtering options.</td>
 		<td valign="top"><code>array</code></td>
 		<td valign="top"><code>['text']</code></td>
 	</tr>
 	<tr>
-		<td valign="top"><code>searchConjunction</td>
+		<td valign="top"><code>hideSearch</code></td>
+		<td valign="top">A boolean value to indicate if the text search option should be hidden.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>false</code></td>
+	</tr>
+	<tr>
+		<td valign="top"><code>searchConjunction</code></td>
 		<td valign="top">When searching for multiple terms (separated by space), this is the operator used. Can be <code>'and'</code> or <code>'or'</code> .</td>
 		<td valign="top"><code>string</code></td>
 		<td valign="top"><code>'and'</code></td>
 	</tr>
 	<tr>
-		<td valign="top"><code>lockOptgroupOrder</td>
+		<td valign="top"><code>lockOptgroupOrder</code></td>
 		<td valign="top">If truthy, Selectize will make all optgroups be in the same order as they were added (by the `$order` property). Otherwise, it will order based on the score of the results in each.</td>
 		<td valign="top"><code>boolean</code></td>
 		<td valign="top"><code>false</code></td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "selectize",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "dist/js/selectize.js",
   "description": "Selectize is a jQuery-based custom <select> UI control. Useful for tagging, contact lists, country selectors, etc.",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "author": "Brian Reavis <brian@thirdroute.com>",
   "license": "Apache-2.0",
   "repository": {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -38,6 +38,7 @@ Selectize.defaults = {
 	sortField: '$order',
 	searchField: ['text'],
 	searchConjunction: 'and',
+	hideSearch: false,
 
 	mode: null,
 	wrapperClass: 'selectize-control',

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -139,6 +139,11 @@ $.extend(Selectize.prototype, {
 		$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
 		$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);
 
+		if (self.settings.hideSearch === true) {
+			// Using the style attribute directly is a workaround for the jquery .css() function limitation ".css() ignores !important declarations"
+			$control_input.attr('style', 'display: none !important');
+		}
+
 		if(inputId = $input.attr('id')) {
 			$control_input.attr('id', inputId + '-selectized');
 			$("label[for='"+inputId+"']").attr('for', inputId + '-selectized');
@@ -1692,7 +1697,7 @@ $.extend(Selectize.prototype, {
 			.toggleClass('invalid', self.isInvalid)
 			.toggleClass('locked', isLocked)
 			.toggleClass('full', isFull).toggleClass('not-full', !isFull)
-			.toggleClass('input-active', self.isFocused && !self.isInputHidden)
+			.toggleClass('input-active', self.isFocused && !self.isInputHidden && self.settings.hideSearch !== true)
 			.toggleClass('dropdown-active', self.isOpen)
 			.toggleClass('has-options', !$.isEmptyObject(self.options))
 			.toggleClass('has-items', self.items.length > 0);

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -132,6 +132,18 @@
 				});
 			});
 
+			it('should hide the text search input when hideSearch=true', function(done) {
+				var test = setup_test('<select>' +
+					'<option value="a">A</option>' +
+					'<option value="b">B</option>' +
+				'</select>', {hideSearch: true});
+
+				click(test.selectize.$control, function() {
+					expect(test.selectize.$control_input.is(':visible')).to.be.equal(false);
+					done();
+				});
+			});
+
 		});
 
 		describe('clicking label', function() {


### PR DESCRIPTION
As the title says, here are the necessary code changes for being able to hide the text search option in a selectize dropdown.
I followed the guidelines at https://github.com/selectize/selectize.js#contributing : 
 - I added a test
 - I ran all tests
 - Updated the CHANGELOG
 - With that, had to update the version number
 - Kept the commit clean

I did see there already was a PR for the issue #110, but since it did not follow any of the guidelines, I suspected that is why it is being ignored.

Could I please at least get a response to this PR? Thanks a lot!