### PR TITLE
removed unused var, cleaned up examples

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
 	});
 
 	grunt.registerTask('build_standalone', '', function() {
-		var files, i, n, source, name, path, modules = [];
+		var i, n, source, name, path, modules = [];
 
 		// amd definitions must be changed to be not anonymous
 		// @see https://github.com/brianreavis/selectize.js/issues/89

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -19,18 +19,18 @@ $(function() {
 			var lines = code.split('\n');
 			var indent = null;
 
-			for (var i = 0; i < lines.length; i++) {
-				if (/^[	 ]*$/.test(lines[i])) continue;
+			for (var j = 0; j < lines.length; j++) {
+				if (/^[	 ]*$/.test(lines[j])) continue;
 				if (!indent) {
-					var lineindent = lines[i].match(/^([ 	]+)/);
+					var lineindent = lines[j].match(/^([ 	]+)/);
 					if (!lineindent) break;
-					indent = lineindent[1];
+					indent = lineindent[j];
 				}
-				lines[i] = lines[i].replace(new RegExp('^' + indent), '');
+				lines[j] = lines[j].replace(new RegExp('^' + indent), '');
 			}
 
-			var code = $.trim(lines.join('\n')).replace(/	/g, '    ');
-			var $pre = $('<pre>').addClass('js').text(code);
+			var code2 = $.trim(lines.join('\n')).replace(/	/g, '    ');
+			var $pre = $('<pre>').addClass('js').text(code2);
 			$pre.insertAfter(this);
 		}
 	});


### PR DESCRIPTION
I'm looking to get into open source, and used a code scanner called SonarQube on a project that was using Selectize which identified bugs in the dist/, examples/, and Gruntfile. I made changes to examples and the Gruntfile to fix these bugs.