### PR TITLE
Update selectize.js

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1707,7 +1707,7 @@ $.extend(Selectize.prototype, {
 	 * @returns {boolean}
 	 */
 	isFull: function() {
-		return this.settings.maxItems !== null && this.items.length >= this.settings.maxItems;
+		return this.settings.create && this.settings.maxItems !== null && this.items.length >= this.settings.maxItems;
 	},
 
 	/**


### PR DESCRIPTION
isFull function is returning true although create option is false. This blocks search feature in certain scenarios. This change will make sure the create option is true before comparing maxItems to length of items.