### PR TITLE
onClick opens the dropdown

### DIFF
--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -1494,6 +1494,7 @@
 	    // closeAfterSelect
 			if (!self.isFocused || !self.isOpen) {
 				self.focus();
+				self.open();
 				e.preventDefault();
 			}
 		},


### PR DESCRIPTION
Added "self.open();" in onClick() event at line 1497 to open the dropdown list with single click inside the input field. Earlier one needs to click multiple times or navigate with the down arrow key only.