### PR TITLE
docs: Fix simple typo, hightlight -> highlight

### DIFF
--- a/dist/js/selectize.js
+++ b/dist/js/selectize.js
@@ -51,7 +51,7 @@
 				}
 			} 
 			// Recurse element node, looking for child text nodes to highlight, unless element 
-			// is childless, <script>, <style>, or already highlighted: <span class="hightlight">
+			// is childless, <script>, <style>, or already highlighted: <span class="highlight">
 			else if (node.nodeType === 1 && node.childNodes && !/(script|style)/i.test(node.tagName) && ( node.className !== 'highlight' || node.tagName !== 'SPAN' )) {
 				for (var i = 0; i < node.childNodes.length; ++i) {
 					i += highlight(node.childNodes[i]);

--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -687,7 +687,7 @@
 				}
 			} 
 			// Recurse element node, looking for child text nodes to highlight, unless element 
-			// is childless, <script>, <style>, or already highlighted: <span class="hightlight">
+			// is childless, <script>, <style>, or already highlighted: <span class="highlight">
 			else if (node.nodeType === 1 && node.childNodes && !/(script|style)/i.test(node.tagName) && ( node.className !== 'highlight' || node.tagName !== 'SPAN' )) {
 				for (var i = 0; i < node.childNodes.length; ++i) {
 					i += highlight(node.childNodes[i]);

--- a/src/contrib/highlight.js
+++ b/src/contrib/highlight.js
@@ -29,7 +29,7 @@ var highlight = function($element, pattern) {
 			}
 		} 
 		// Recurse element node, looking for child text nodes to highlight, unless element 
-		// is childless, <script>, <style>, or already highlighted: <span class="hightlight">
+		// is childless, <script>, <style>, or already highlighted: <span class="highlight">
 		else if (node.nodeType === 1 && node.childNodes && !/(script|style)/i.test(node.tagName) && ( node.className !== 'highlight' || node.tagName !== 'SPAN' )) {
 			for (var i = 0; i < node.childNodes.length; ++i) {
 				i += highlight(node.childNodes[i]);


### PR DESCRIPTION
There is a small typo in dist/js/selectize.js, dist/js/standalone/selectize.js, src/contrib/highlight.js.

Should read `highlight` rather than `hightlight`.

