### PR TITLE
Handle Selectize input in side-by-side button group

### DIFF
--- a/src/less/selectize.bootstrap3.less
+++ b/src/less/selectize.bootstrap3.less
@@ -148,3 +148,9 @@
 	.selectize-box-shadow(none);
 	.selectize-border-radius(0);
 }
+
+// Handle Selectize input in side-by-side button groups. Follows button-groups.less in Bootstrap source.
+.btn-group > .selectize-control:not(:last-child) > .selectize-input {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+}


### PR DESCRIPTION
Fix border radius of Selectize input when side-by-side with another button. Mirrors what Bootstrap does for non-Selectize side-by-side inputs.