### PR TITLE
Add jQuery-UI as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Interface with it and make modifications easily. Pull requests welcome!
 - [sifter](https://github.com/brianreavis/sifter.js) (bundled in ["standalone" build](dist/js/standalone))
 - [microplugin](https://github.com/brianreavis/microplugin.js) (bundled in ["standalone" build](dist/js/standalone))
 
+**Optional:**
+
+- [jquery-ui](https://github.com/jquery/jquery-ui) (required by `drag_drop` plugin)
+
 ### Installation and files
 
 All pre-built files needed to use Selectize can be found in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -4936,6 +4936,12 @@
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
       "dev": true
     },
+    "jquery-ui": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.10.4.tgz",
+      "integrity": "sha1-oJb+X04PKraaBYXPEEVYd/V1Br0=",
+      "optional": true
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
   },
   "engines": {
     "node": "*"
+  },
+  "optionalDependencies": {
+    "jquery-ui": "^1.10.4"
   }
 }


### PR DESCRIPTION
to make some functionality to work, like the `drag_drop` plugin.
The dependency wasn't explicit but just hidden in the code.

Plugin is pretty old, so the lowest jquery-ui version available
on npmjs.com/package/ has been chosen. However it is possible to
install the latest version, inside the user's project.

Also, update the list of dependencies into the readme.

See: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#optionaldependencies

closes #753, #1366
issue #474