### PR TITLE
Rectified #1164 issue, considered previously fixed

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1811,7 +1811,7 @@ $.extend(Selectize.prototype, {
 			// Do not trigger blur while inside a blur event,
 			// this fixes some weird tabbing behavior in FF and IE.
 			// See #1164
-			if (!self.isBlurring) {
+			if (self.isBlurring) {
 				self.$control_input.blur(); // close keyboard on iOS
 			}
 		}


### PR DESCRIPTION
Rectified #1164 issue considered previously fixed, done with the pull
https://github.com/selectize/selectize.js/pull/1353 and
pushed commit
https://github.com/michael-maltsev/selectize.js/commit/f6e9faa9fe8e0c2e2500a5517264ca8795ec4c16

This has to be ``if (self.isBlurring) {`` and not ``if (!self.isBlurring) {``
Reasons
 - The problem still exists from 0.12.3 - 0.12.6 version.
 - Have changed it to ``if (self.isBlurring) {`` and control behaves perfectly in my initial tests.
 - My two cents here, when we are replacing ``ignoreFocus`` with ``isBlurring`` and have initialized both flags with same boolean values everywhere in the code, shouldn't the if statement should also be similar?
