### PR TITLE
Autoselect option based on typed text on focusout

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -762,6 +762,16 @@ $.extend(Selectize.prototype, {
 	},
 
 	/**
+	 * Gets the value of input field of the control.
+	 *
+	 * @returns {string} value
+	 */
+	getTextboxValue: function() {
+		var $input = this.$control_input;
+		return $input.val();
+	},
+
+	/**
 	 * Sets the input field of the control to the specified value.
 	 *
 	 * @param {string} value
@@ -1456,6 +1466,34 @@ $.extend(Selectize.prototype, {
 	},
 
 	/**
+	 * Finds the first element with a "textContent" property
+	 * that matches the given textContent value.
+	 *
+	 * @param {mixed} textContent
+	 * @param {boolean} ignoreCase
+	 * @param {object} $els
+	 * @return {object}
+	 */
+	getElementWithTextContent: function(textContent, ignoreCase ,$els) {
+		textContent = hash_key(textContent);
+
+		if (typeof textContent !== 'undefined' && textContent !== null) {
+			for (var i = 0, n = $els.length; i < n; i++) {
+				var eleTextContent = $els[i].textContent
+				if (ignoreCase == true) {
+					eleTextContent = (eleTextContent !== null) ? eleTextContent.toLowerCase() : null;
+					textContent = textContent.toLowerCase();
+				}
+				if (eleTextContent === textContent) {
+					return $($els[i]);
+				}
+			}
+		}
+
+		return $();
+	},
+
+	/**
 	 * Returns the jQuery element of the item
 	 * matching the given value.
 	 *
@@ -1464,6 +1502,18 @@ $.extend(Selectize.prototype, {
 	 */
 	getItem: function(value) {
 		return this.getElementWithValue(value, this.$control.children());
+	},
+
+	/**
+	 * Returns the jQuery element of the item
+	 * matching the given textContent.
+	 *
+	 * @param {string} value
+	 * @param {boolean} ignoreCase
+	 * @returns {object}
+	 */
+	getFirstItemMatchedByTextContent: function(textContent, ignoreCase = false) {
+		return this.getElementWithTextContent(textContent, ignoreCase, this.$dropdown_content.find('[data-selectable]'));
 	},
 
 	/**

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1524,7 +1524,8 @@ $.extend(Selectize.prototype, {
 	 * @param {boolean} ignoreCase
 	 * @returns {object}
 	 */
-	getFirstItemMatchedByTextContent: function(textContent, ignoreCase = false) {
+	getFirstItemMatchedByTextContent: function(textContent, ignoreCase) {
+		ignoreCase = (ignoreCase !== null && ignoreCase === true) ? true : false;
 		return this.getElementWithTextContent(textContent, ignoreCase, this.$dropdown_content.find('[data-selectable]'));
 	},
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -204,7 +204,7 @@ $.extend(Selectize.prototype, {
 			keyup     : function() { return self.onKeyUp.apply(self, arguments); },
 			keypress  : function() { return self.onKeyPress.apply(self, arguments); },
 			resize    : function() { self.positionDropdown.apply(self, []); },
-			blur      : function() { return self.onBlur.apply(self, arguments); },
+			blur      : function() { self.onBeforeBlur.apply(self, arguments);  return self.onBlur.apply(self, arguments); },
 			focus     : function() { self.ignoreBlur = false; return self.onFocus.apply(self, arguments); },
 			paste     : function() { return self.onPaste.apply(self, arguments); }
 		});
@@ -623,6 +623,18 @@ $.extend(Selectize.prototype, {
 		}
 
 		self.refreshState();
+	},
+
+	/**
+	 * Triggered before on <input> blur.
+	 *
+	 * @param {object} e
+	 * @param {Element} dest
+	 */
+	onBeforeBlur: function(e, dest) {
+		var self = this;
+		var $matchedItem = self.getFirstItemMatchedByTextContent(self.lastValue, true);
+		self.setValue($matchedItem.attr('data-value'));
 	},
 
 	/**


### PR DESCRIPTION
 - Added onBeforeBlur functionality.
   - On a blur event, before calling **onBlur**, an **onBeforeBlur** function is called, which checks that the text typed in the input box is an exact match of any option provided in the select control ( letter case is ignored ), if an option is found, that option is selected.
-  Added functions like getTextboxValue, getElementWithTextContent, getFirstItemMatchedByTextContent
   - **getTextboxValue**: Gets the current value of input control.
   - **getElementWithTextContent**: Finds the first element with a "textContent" property (innerHTML) that matches the given string provided for search..
   - **getFirstItemMatchedByTextContent**: Returns the jQuery element of the item matching the given textContent / innerHTML.
