### PR TITLE
Don't replace all versions in package-lock.json during release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: compile release test
 plugins=*
 GRUNT=node_modules/.bin/grunt
+CURRENT_VERSION := $(shell sed -n '/"version":/{s/.*"version": "\([^"]*\)".*/\1/p;q}' package.json)
 
 all: compile
 test:
@@ -16,7 +17,7 @@ ifeq ($(strip $(version)),)
 else
 	sed -i.bak 's/"version": "[^"]*"/"version": "$(version)"/' selectize.jquery.json
 	sed -i.bak 's/"version": "[^"]*"/"version": "$(version)"/' package.json
-	sed -i.bak 's/"version": "[^"]*"/"version": "$(version)"/' package-lock.json
+	sed -i.bak "s/\"version\": \"$(CURRENT_VERSION)\"/\"version\": \"$(version)\"/" package-lock.json
 	rm *.bak
 	make compile
 	npm test || exit 1


### PR DESCRIPTION
This change doesn't fully fix the original issue but it reduces impact area as now we only replace old version. The better solution is to replace only the first occurence or replace a version only if it is the next line after a package name (this can be done wih multiline regexps).

P.S. This problem took my attention only because you wrote a good commit message  in 0979580bf224151e4fa3db1b217e4e2e87ce99f1 ;)