### PR TITLE
Resolved focus cycle problem in firefox.

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -137,7 +137,7 @@ $.extend(Selectize.prototype, {
 		$control_input    = $('<input type="text" autocomplete="new-password" autofill="no" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 		$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 		$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
-		$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);
+		$dropdown_content = $('<div tabindex="-1">').addClass(settings.dropdownContentClass).appendTo($dropdown);
 
 		if(inputId = $input.attr('id')) {
 			$control_input.attr('id', inputId + '-selectized');


### PR DESCRIPTION
For those dropdown where it doesn't show scrollbar the focus cycle works properly, but for those dropdowns having enough options to show scrollbar the focus cycle gives problem.
This commit removes the scrollbar div from the focus group by adding tabindex="-1" to the dropdown.