### PR TITLE
Resets the dropdown selection to top, if input is cleared.

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1199,7 +1199,7 @@ $.extend(Selectize.prototype, {
 		if (self.hasOptions) {
 			if (results.items.length > 0) {
 				$active_before = active_before && self.getOption(active_before);
-				if ($active_before && $active_before.length) {
+				if (results.query !== "" && $active_before && $active_before.length) {
 					$active = $active_before;
 				} else if (self.settings.mode === 'single' && self.items.length) {
 					$active = self.getOption(self.items[0]);


### PR DESCRIPTION
When user types in the input field, and a particular option gets selected, if the user clears the input field, the older option remains selected, this PR rectifies by selecting the topmost option.
### **Older:**
![older](https://user-images.githubusercontent.com/3785927/108787205-4ac90200-759b-11eb-873b-6524d0997e01.gif)


### **Post PR:**
Once this patch is applied you can see post clearing the input field,
the selection moves to the top most element.
![post_pr](https://user-images.githubusercontent.com/3785927/108787357-94b1e800-759b-11eb-9e0f-7182198a9474.gif)
