### PR TITLE
Removed gap between cursor and text.

### DIFF
--- a/src/scss/selectize.scss
+++ b/src/scss/selectize.scss
@@ -76,7 +76,7 @@ $select-arrow-size: 5px !default;
 $select-arrow-color: #808080 !default;
 $select-arrow-offset: 15px !default;
 
-$select-caret-margin: 0 4px !default;
+$select-caret-margin: 0 0px !default;
 $select-caret-margin-rtl: 0 4px 0 -2px !default;
 
 $select-spinner-size: 30px;


### PR DESCRIPTION
When we focus on the control and there is option already default set or selected, it shows a gap between the text and the cursor and it gives a wrong impression that a space is present, when the user tries to erase just the space using backspace key the whole option is erased. Showing the difference below

### Before PR
![before](https://user-images.githubusercontent.com/3785927/108943109-39a4f180-767e-11eb-9d14-c433614350ab.gif)

### After PR
![after](https://user-images.githubusercontent.com/3785927/108943121-3d387880-767e-11eb-97c2-299ddf70ae53.gif)
