### PR TITLE
Update backspace action on dropdown.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,6 +148,12 @@ $(function() {
 		<td valign="top"><code>60</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>dropdownOnBackspaceGotoTop</code></td>
+		<td valign="top">If an option is selected, the same option is highlighted/marked active in the dropdown, pressing backspace on the input control removes the option and in dropdown the previous element is highlight. When this option is set to `true` it shifts the highlight to the topmost option.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>false</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>loadThrottle</code></td>
 		<td valign="top">The number of milliseconds to wait before requesting options from the server or null. If null, throttling is disabled. Useful when loading options dynamically while the user types a search / filter expression.</td>
 		<td valign="top"><code>int</code></td>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,10 +148,10 @@ $(function() {
 		<td valign="top"><code>60</code></td>
 	</tr>
 	<tr>
-		<td valign="top"><code>dropdownOnBackspaceGotoTop</code></td>
-		<td valign="top">If an option is selected, the same option is highlighted/marked active in the dropdown, pressing backspace on the input control removes the option and in dropdown the previous element is highlight. When this option is set to `true` it shifts the highlight to the topmost option.</td>
-		<td valign="top"><code>boolean</code></td>
-		<td valign="top"><code>false</code></td>
+		<td valign="top"><code>deselectBehavior</code></td>
+		<td valign="top">If an option is selected, the same option is highlighted/marked active in the dropdown, pressing backspace on the input control removes the option and in dropdown the previous element is highlight. When this option is set to `top` it shifts the highlight to the topmost option. Valid options are `top` and `previous`.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>previous</code></td>
 	</tr>
 	<tr>
 		<td valign="top"><code>loadThrottle</code></td>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -23,6 +23,7 @@ Selectize.defaults = {
 	closeAfterSelect: false,
 
 	scrollDuration: 60,
+	dropdownOnBackspaceGotoTop: false,
 	loadThrottle: 300,
 	loadingClass: 'loading',
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -23,7 +23,7 @@ Selectize.defaults = {
 	closeAfterSelect: false,
 
 	scrollDuration: 60,
-	dropdownOnBackspaceGotoTop: false,
+	deselectBehavior: 'previous', //top, previous
 	loadThrottle: 300,
 	loadingClass: 'loading',
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1967,7 +1967,11 @@ $.extend(Selectize.prototype, {
 		selection = getSelection(self.$control_input[0]);
 
 		if (self.$activeOption && !self.settings.hideSelected) {
-			option_select = self.getFirstOption().attr('data-value');
+			if (typeof self.settings.dropdownOnBackspaceGotoTop === 'boolean' && self.settings.dropdownOnBackspaceGotoTop) {
+				option_select = self.getFirstOption().attr('data-value');
+			} else {
+				option_select = self.getAdjacentOption(self.$activeOption, -1).attr('data-value');
+			}
 		}
 
 		// determine items that will be removed

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1437,6 +1437,17 @@ $.extend(Selectize.prototype, {
 	},
 
 	/**
+	 * Returns the jQuery element of the first
+	 * selectable option.
+	 *
+	 * @return {object}
+	 */
+	getFirstOption: function() {
+		var $options = this.$dropdown.find('[data-selectable]');
+		return $options.length > 0 ? $options.eq(0) : $();
+	},
+
+	/**
 	 * Returns the jQuery element of the next or
 	 * previous selectable option.
 	 *
@@ -1956,7 +1967,7 @@ $.extend(Selectize.prototype, {
 		selection = getSelection(self.$control_input[0]);
 
 		if (self.$activeOption && !self.settings.hideSelected) {
-			option_select = self.getAdjacentOption(self.$activeOption, -1).attr('data-value');
+			option_select = self.getFirstOption().attr('data-value');
 		}
 
 		// determine items that will be removed

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1967,7 +1967,7 @@ $.extend(Selectize.prototype, {
 		selection = getSelection(self.$control_input[0]);
 
 		if (self.$activeOption && !self.settings.hideSelected) {
-			if (typeof self.settings.dropdownOnBackspaceGotoTop === 'boolean' && self.settings.dropdownOnBackspaceGotoTop) {
+			if (typeof self.settings.deselectBehavior === 'string' && self.settings.deselectBehavior === 'top') {
 				option_select = self.getFirstOption().attr('data-value');
 			} else {
 				option_select = self.getAdjacentOption(self.$activeOption, -1).attr('data-value');


### PR DESCRIPTION
Whenever we clear an option using backspace, the selection moves one step upward. This creates confusion as when user deletes and presses tab (given `selectOnTab: true` ), the above option gets selected automatically, whereas deletion should move it to the top of the list.

### Before PR
![Before](https://user-images.githubusercontent.com/3785927/108946497-8ab7e400-7684-11eb-9fbd-f8b4add87564.gif)

### After PR
![After](https://user-images.githubusercontent.com/3785927/108946508-8f7c9800-7684-11eb-8fe6-0b3ebae53bc1.gif)
