### PR TITLE
Added formatValueToKey caller function

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -320,6 +320,12 @@ $(function() {
 		<td valign="top"><code>null</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>formatValueToKey(key)</code></td>
+		<td valign="top">Function to generate <strong>key</strong> for a new item created from input when create is set to true, to generate a `'key' => 'value'` combination. Without using this function, it will result in `'value' => 'value'` combination. The provided function should return a <strong>key</strong> that is not object or function.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>null</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>onInitialize()</code></td>
 		<td valign="top">Invoked once the control is completely initialized.</td>
 		<td valign="top"><code>function</code></td>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -52,7 +52,7 @@ Selectize.defaults = {
 	/*
 	load                 : null, // function(query, callback) { ... }
 	score                : null, // function(search) { ... }
-	formatValueToKey     : null, // function() { ... }
+	formatValueToKey     : null, // function(key) { ... }
 	onInitialize         : null, // function() { ... }
 	onChange             : null, // function(value) { ... }
 	onItemAdd            : null, // function(value, $item) { ... }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -52,6 +52,7 @@ Selectize.defaults = {
 	/*
 	load                 : null, // function(query, callback) { ... }
 	score                : null, // function(search) { ... }
+	formatValueToKey     : null, // function() { ... }
 	onInitialize         : null, // function() { ... }
 	onChange             : null, // function(value) { ... }
 	onItemAdd            : null, // function(value, $item) { ... }

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1691,7 +1691,14 @@ $.extend(Selectize.prototype, {
 		var setup = (typeof self.settings.create === 'function') ? this.settings.create : function(input) {
 			var data = {};
 			data[self.settings.labelField] = input;
-			data[self.settings.valueField] = input;
+			var key = input;
+			if ( self.settings.formatValueToKey && typeof self.settings.formatValueToKey === 'function' ) {
+				key = self.settings.formatValueToKey.apply(this, [key]);
+				if (key === null || typeof key === 'undefined' || typeof key === 'object' || typeof key === 'function') {
+					throw new Error('Selectize "formatValueToKey" setting must be a function that returns a value other than object or function.');
+				}
+			}
+			data[self.settings.valueField] = key;
 			return data;
 		};
 


### PR DESCRIPTION
When `create: true` and a new item is created, the `'key' => 'value'` combination is created where both the `key` and `value` is set to the input value in the inputbox, the `key` is used to create the `data-value` and the `value` is used as the `text` displayed for the option. At times you need to change the key, for e.g. you want the key to be lowercase of value, you can use `formatValueToKey` function as follows to do so.

```
element.selectize({
    create: true,
    formatValueToKey: function(key) {
        return key.toLowerCase();
    },
```