### PR TITLE
Show empty option in dropdown and label for that empty option.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -142,6 +142,18 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>showEmptyOptionInDropdown</code></td>
+		<td valign="top">If true, Selectize will show an option with value `""` in dropdown, if one does not exist; which is required when you want to select a empty option via `selectOnTab`. This requires `allowEmptyOption: true`.</td>
+		<td valign="top"><code>boolean</code></td>
+		<td valign="top"><code>false</code></td>
+	</tr>
+	<tr>
+		<td valign="top"><code>emptyOptionLabel</code></td>
+		<td valign="top">If `showEmptyOptionInDropdown: true` and an option with value `""` in dropdown does not exist, an option with `""` value is created, the label/text of the option can be set via this option, this requires `showEmptyOptionInDropdown: true`.</td>
+		<td valign="top"><code>string</code></td>
+		<td valign="top"><code>'--'</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>scrollDuration</code></td>
 		<td valign="top">The animation duration (in milliseconds) of the scroll animation triggered when going [up] and [down] in the options dropdown.</td>
 		<td valign="top"><code>int</code></td>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -20,6 +20,8 @@ Selectize.defaults = {
 	selectOnTab: true,
 	preload: false,
 	allowEmptyOption: false,
+	showEmptyOptionInDropdown: false,
+	emptyOptionLabel: '--',
 	closeAfterSelect: false,
 
 	scrollDuration: 60,

--- a/src/scss/selectize.bootstrap3.scss
+++ b/src/scss/selectize.bootstrap3.scss
@@ -84,6 +84,10 @@ $select-arrow-offset: $select-padding-x + 5px;
   padding: 5px 0;
 }
 
+.#{$selectize}-dropdown-emptyoptionlabel {
+	text-align: center;
+}
+
 .#{$selectize}-input {
   min-height: $input-height-base;
 

--- a/src/scss/selectize.bootstrap4.scss
+++ b/src/scss/selectize.bootstrap4.scss
@@ -99,6 +99,10 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
   padding: 5px 0;
 }
 
+.#{$selectize}-dropdown-emptyoptionlabel {
+	text-align: center;
+}
+
 .#{$selectize}-input {
   min-height: $input-height;
   @include box-shadow($input-box-shadow);

--- a/src/scss/selectize.scss
+++ b/src/scss/selectize.scss
@@ -302,6 +302,10 @@ $select-spinner-border-color: $select-color-border;
   overflow-scrolling: touch;
 }
 
+.#{$selectize}-dropdown-emptyoptionlabel {
+	text-align: center;
+}
+
 .#{$selectize}-dropdown .spinner {
   display: inline-block;
   width: $select-spinner-size;

--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -139,6 +139,10 @@ $.fn.selectize = function(settings_user) {
 		if (!placeholder && !settings.allowEmptyOption) {
 			placeholder = $input.children('option[value=""]').text();
 		}
+		if (settings.allowEmptyOption && settings.showEmptyOptionInDropdown && !$input.children('option[value=""]').length) {
+			var input_html = $input.html();
+			$input.html('<option value="">'+settings.emptyOptionLabel+'</option>'+input_html);
+		}
 
 		var settings_element = {
 			'placeholder' : placeholder,

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -297,6 +297,7 @@ $.extend(Selectize.prototype, {
 	setupTemplates: function() {
 		var self = this;
 		var field_label = self.settings.labelField;
+		var field_value = self.settings.valueField;
 		var field_optgroup = self.settings.optgroupLabelField;
 
 		var templates = {
@@ -307,7 +308,7 @@ $.extend(Selectize.prototype, {
 				return '<div class="optgroup-header">' + escape(data[field_optgroup]) + '</div>';
 			},
 			'option': function(data, escape) {
-				return '<div class="option">' + escape(data[field_label]) + '</div>';
+				return '<div class="option '+( data[field_value] === '' ? 'selectize-dropdown-emptyoptionlabel' : '')+'">' + escape(data[field_label]) + '</div>';
 			},
 			'item': function(data, escape) {
 				return '<div class="item">' + escape(data[field_label]) + '</div>';


### PR DESCRIPTION
Added the following settings.
### 1. showEmptyOptionInDropdown ( Default: false )
If true, Selectize will show an option with value `""` in dropdown, if one does not exist; which is useful when you want to select a empty option via `selectOnTab`. This requires `allowEmptyOption` also set to `true`.

### 2. emptyOptionLabel ( Default: -- )
If `showEmptyOptionInDropdown: true` and an option with value `""` in dropdown does not exist, an option with `""` value is created, the label/text of the option can be set via this option, this requires `showEmptyOptionInDropdown: true`.

### 3. Added class `selectize-dropdown-emptyoptionlabel` to center align the `emptyOptionLabel`

Post PR
![after](https://user-images.githubusercontent.com/3785927/109227938-1c3f6700-77e7-11eb-9dfa-260919c48921.gif)
