### PR TITLE
Change 'keyup' event to 'input' event.

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -202,8 +202,8 @@ $.extend(Selectize.prototype, {
 		$control_input.on({
 			mousedown : function(e) { e.stopPropagation(); },
 			keydown   : function() { return self.onKeyDown.apply(self, arguments); },
-			keyup     : function() { return self.onKeyUp.apply(self, arguments); },
 			keypress  : function() { return self.onKeyPress.apply(self, arguments); },
+			input     : function() { return self.onInput.apply(self, arguments); },
 			resize    : function() { self.positionDropdown.apply(self, []); },
 			blur      : function() { return self.onBlur.apply(self, arguments); },
 			focus     : function() { self.ignoreBlur = false; return self.onFocus.apply(self, arguments); },
@@ -564,15 +564,14 @@ $.extend(Selectize.prototype, {
 	},
 
 	/**
-	 * Triggered on <input> keyup.
+	 * Triggered on <input> input.
 	 *
 	 * @param {object} e
 	 * @returns {boolean}
 	 */
-	onKeyUp: function(e) {
+	onInput: function(e) {
 		var self = this;
 
-		if (self.isLocked) return e && e.preventDefault();
 		var value = self.$control_input.val() || '';
 		if (self.lastValue !== value) {
 			self.lastValue = value;


### PR DESCRIPTION
Change keyup event to input event that used on detect changes of input (for search), because keyup event does not detect some input method (like mobile multi language keyboard, linux multi language IME).

Also deleted preventDefault method because both keyup and input event can not be canceled.

The input event was recommaned on MDN ( https://developer.mozilla.org/en-US/docs/Web/API/Document/keyup_event ).

Test passed: phantomjs, Firefox, Chrome. (Linux)
Related issues: #1156

* Sry for new test, I don't know how can I simulate multi language IME on phantomjs. :(