### PR TITLE
Fix the two closed issues #1012 and #1401

### DIFF
--- a/src/plugins/drag_drop/plugin.js
+++ b/src/plugins/drag_drop/plugin.js
@@ -1,7 +1,7 @@
 /**
  * Plugin: "drag_drop" (selectize.js)
  * Copyright (c) 2013 Brian Reavis & contributors
- * Copyright (c) 2020 Selectize Team & contributors* 
+ * Copyright (c) 2020 Selectize Team & contributors*
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:
@@ -58,8 +58,11 @@ Selectize.define('drag_drop', function(options) {
 					$control.children('[data-value]').each(function() {
 						values.push($(this).attr('data-value'));
 					});
+					self.isFocused = false;
 					self.setValue(values);
+					self.isFocused = true;
 					self.setActiveItem(active);
+					self.positionDropdown();
 				}
 			});
 		};


### PR DESCRIPTION
- #1401
This was still an issue at least when the options are covering multiple
lines.

- #1012
selectize "greedily" opens its select box in the multi-select case when
the options are updated. This can be seen here. This is triggered around
line 1613 in selectize.js, function addItem():

```
self.refreshOptions(self.isFocused && inputMode !== 'single');
```

refreshOptions() causes the drop-down menu to open if called with
"true". The hack-around is to fake "not-focussed" in the plugin.

Of course, the for me irritating behaviour might be a design decision.
But I do not like the drop-down to open when I just want to rearrange
the tags.