### PR TITLE
Fix missing px unit on $select-width-item-border.

### DIFF
--- a/src/scss/selectize.scss
+++ b/src/scss/selectize.scss
@@ -61,7 +61,7 @@ $select-border: 1px solid $select-color-border !default;
 $select-dropdown-border: 1px solid $select-color-dropdown-border !default;
 $select-border-radius: 3px !default;
 
-$select-width-item-border: 0 !default;
+$select-width-item-border: 0px !default;
 $select-max-height-dropdown: 200px !default;
 
 $select-padding-x: 8px !default;


### PR DESCRIPTION
Omitting the units results in a rule like
```
.selectize-control.multi .selectize-input.has-items {
    padding: calc( 8px - 2px - 0 ) 8px calc( 8px - 2px - 3px - 0 );
}
```
At least firefox does not tolerate adding a plain "0" without the unit.
As a result the height of the widget is computed wrongly if items are
selected.