### PR TITLE
drag-drop "overflow" changing causes control container height to fluctuate

### DIFF
--- a/src/plugins/drag_drop/plugin.js
+++ b/src/plugins/drag_drop/plugin.js
@@ -49,10 +49,12 @@ Selectize.define('drag_drop', function(options) {
 				disabled: self.isLocked,
 				start: function(e, ui) {
 					ui.placeholder.css('width', ui.helper.css('width'));
-					$control.css({overflow: 'visible'});
+					// $control.css({overflow: 'visible'});
+					$control.addClass('dragging');
 				},
 				stop: function() {
-					$control.css({overflow: 'hidden'});
+					// $control.css({overflow: 'hidden'});
+					$control.removeClass('dragging');
 					var active = self.$activeItems ? self.$activeItems.slice() : null;
 					var values = [];
 					$control.children('[data-value]').each(function() {

--- a/src/plugins/drag_drop/plugin.scss
+++ b/src/plugins/drag_drop/plugin.scss
@@ -1,4 +1,7 @@
 .#{$selectize}-control.plugin-drag_drop {
+  &.multi > .#{$selectize}-input.dragging {
+    overflow: visible;
+  }
   &.multi > .#{$selectize}-input > div.ui-sortable-placeholder {
     visibility: visible !important;
     background: #f2f2f2 !important;

--- a/src/scss/selectize.scss
+++ b/src/scss/selectize.scss
@@ -121,7 +121,7 @@ $select-spinner-border-color: $select-color-border;
   padding: $select-padding-y $select-padding-x;
   display: inline-block;
   width: 100%;
-  overflow: hidden;
+  // overflow: hidden;
   position: relative;
   z-index: 1;
   box-sizing: border-box;


### PR DESCRIPTION
This is of course w.r.t. the drag-drop plugin.

The fix is to remove "overflow: hidden" from the default style and  do
the necessary "overflow: visible" for the drag-drop plugin by setting a
css-class.