### PR TITLE
Only copy type from $input to $control_input if $input actually is an…

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -180,7 +180,9 @@ $.extend(Selectize.prototype, {
 		if ($input.attr('autocapitalize')) {
 			$control_input.attr('autocapitalize', $input.attr('autocapitalize'));
 		}
-		$control_input[0].type = $input[0].type;
+		if ($input.is('input')) {
+			$control_input[0].type = $input[0].type;
+		}
 
 		self.$wrapper          = $wrapper;
 		self.$control          = $control;


### PR DESCRIPTION
… input.

If $input is not actually an <input .../> but e.g. a select then blindly
copying $input.type results in an undefined or strange type property
for the $control_input.