### PR TITLE
selectize.jquery.js For convenience remember the original user-settings.

### DIFF
--- a/src/selectize.jquery.js
+++ b/src/selectize.jquery.js
@@ -158,6 +158,7 @@ $.fn.selectize = function(settings_user) {
 		}
 
 		instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, settings_user));
+		instance.settings_user = settings_user;
 	});
 };
 


### PR DESCRIPTION
The use case is to hard-destroy the widget and recreate it with the
original settings, without having to remember them externally.