### PR TITLE
refreshItems(): add "silent" option.

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1544,7 +1544,7 @@ $.extend(Selectize.prototype, {
 	 * "Selects" multiple items at once. Adds them to the list
 	 * at the current caret position.
 	 *
-	 * @param {string} value
+	 * @param {string} values
 	 * @param {boolean} silent
 	 */
 	addItems: function(values, silent) {
@@ -1743,15 +1743,15 @@ $.extend(Selectize.prototype, {
 	/**
 	 * Re-renders the selected item lists.
 	 */
-	refreshItems: function() {
+	refreshItems: function(silent) {
 		this.lastQuery = null;
 
 		if (this.isSetup) {
-			this.addItem(this.items);
+			this.addItem(this.items, silent);
 		}
 
 		this.refreshState();
-		this.updateOriginalInput();
+		this.updateOriginalInput({silent: silent});
 	},
 
 	/**


### PR DESCRIPTION
This is meant for the case where refreshItems() is called
programmatically and hence the change event is not needed, or even bound
to a handler which rather would react to "external" user input.