### PR TITLE
Fix support for IE 11

### DIFF
--- a/src/plugins/tag_limit/plugin.js
+++ b/src/plugins/tag_limit/plugin.js
@@ -14,13 +14,13 @@ Selectize.define('tag_limit', function (options) {
             if (limit === undefined || $items.length <= limit)
                 return
 
-            $items.toArray().forEach((item, index) => {
+            $items.toArray().forEach(function(item, index) {
                 if (index < limit)
                     return
                 $(item).hide()
             });
 
-            $control.append(`<span><b>+${$items.length - limit}</b></span>`)
+            $control.append('<span><b>' + ($items.length - limit) + '</b></span>')
         };
     })()
 


### PR DESCRIPTION
Remove usage of => and `` strings that break backwards compatibility with IE