### PR TITLE
Use `navigator.userAgentData` for platform detection when available

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,12 @@
-var IS_MAC        = /Mac/.test(navigator.userAgent);
+function uaDetect(platform, re) {
+  if (navigator.userAgentData) {
+    return platform === navigator.userAgentData.platform;
+  }
+
+  return re.test(navigator.userAgent);
+}
+
+var IS_MAC        = uaDetect("macOS", /Mac/);
 
 var KEY_A         = 65;
 var KEY_COMMA     = 188;
@@ -21,4 +29,4 @@ var TAG_SELECT    = 1;
 var TAG_INPUT     = 2;
 
 // for now, android support in general is too spotty to support validity
-var SUPPORTS_VALIDITY_API = !/android/i.test(window.navigator.userAgent) && !!document.createElement('input').validity;
+var SUPPORTS_VALIDITY_API = !uaDetect("Android", /android/i) && !!document.createElement('input').validity;


### PR DESCRIPTION
Closes #1781 

Hope this looks ok! It's my first ever GitHub PR, so apologies for any newbie hiccups!

I ran the tests and got one error, but I don't think it's anything to do with this change...

```bash
Chrome 100.0.4896.127 (Mac OS 10.15.7) Interaction blurring the input should close dropdown when createOnBlur is true FAILED
```