### PR TITLE
Use correct semver syntax for JQuery peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jquery-ui": "^1.13.0"
   },
   "peerDependencies": {
-    "jquery": "^1.7.0, ^2, ^3"
+    "jquery": "^1.7.0 || ^2 || ^3"
   },
   "scripts": {
     "test": "karma start",


### PR DESCRIPTION
Having an issue installing `0.13.5` of the project when I have `jquery@2.2.4` already installed. Noticed that the format of the version for the peerDependency seems to be a bit off for targeting multiple different versions of `jquery`. This should make it possible now to target all versions of 2 and 3 and then 1.0 versions later than 1.7.0. Before I think you had to have `3.6.0` since that would just resolve to the same version as the package.

Verified what semver would target by checking [https://semver.npmjs.com/](https://semver.npmjs.com/)

Prior to these changes

![](https://user-images.githubusercontent.com/2991598/169085081-5d2ad3ec-4778-4c0c-8506-e43738416c69.png)

With these changes 

![](https://user-images.githubusercontent.com/2991598/169085158-b0a4a173-3d26-4c0c-93db-0a3d4487a656.png)