### PR TITLE
Fix bootstrap3 select-width-item-border incompatible value

### DIFF
--- a/src/scss/selectize.bootstrap3.scss
+++ b/src/scss/selectize.bootstrap3.scss
@@ -34,7 +34,7 @@ $select-shadow-input-error-focus: inset 0 1px 1px rgba(0, 0, 0, 0.075),
 $select-border: 1px solid $input-border;
 $select-border-radius: $input-border-radius;
 
-$select-width-item-border: 0;
+$select-width-item-border: 0px;
 $select-padding-x: $padding-base-horizontal;
 $select-padding-y: $padding-base-vertical;
 $select-padding-dropdown-item-x: $padding-base-horizontal;


### PR DESCRIPTION
The propose of the change is to solve a bug when we try to import the `dist/selectize.bootstrap3.css` using a CSS compiler like SASS.

The compiler throw an error of incompatible type in the calc function because we are trying to subtract a pixel value from a non defined value 0.

```
Error: 5px and 0 are incompatible.
  ╷
2 │       6px - 1px - 0
  │       ^^^^^^^^^^^^^
  ╵
  @selectize/selectize/dist/css/selectize.bootstrap3.css 2:7  @import
```

With this change, the result of this expressions will be like `6px - 1px - 0px` instead of 
`6px - 1px - 0` making it compile correctly.