### PR TITLE
Remove link for maintainer wanted

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ![Selectize.js](docs/selectize-wordmark.png)
 
-→ Selectize is looking for [new members on the maintenance team](https://github.com/selectize/selectize.js/issues/752)!
-
 [![NPM version](http://img.shields.io/npm/v/@selectize/selectize.svg?style=flat)](https://www.npmjs.com/package/@selectize/selectize)
 [![CDNJS version](http://img.shields.io/cdnjs/v/selectize.js.svg?style=flat)](https://cdnjs.com/libraries/selectize.js)
 \


### PR DESCRIPTION
New maintainer looks appointed as far as seen https://github.com/selectize/selectize.js/discussions/1678.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>