### PR TITLE
Added a throttle on mousedown preveting the dropdown from reopening after click to close

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -142,6 +142,12 @@ $(function() {
 		<td valign="top"><code>false</code></td>
 	</tr>
 	<tr>
+		<td valign="top"><code>closeDropdownThreshold</code></td>
+		<td valign="top">The number of milliseconds to throttle the opening of the dropdown after it is closed by clicking on the control. Setting this to 0 will reopen the dropdown after clicking on the control when the dropdown is open. This does not affect multi-selects.</td>
+		<td valign="top"><code>int</code></td>
+		<td valign="top"><code>250</code></td>
+	</tr>
+	<tr>
 		<td valign="top"><code>allowEmptyOption</code></td>
 		<td valign="top">If true, Selectize will treat any options with a "" value like normal. This defaults to false to accomodate the common &lt;select&gt; practice of having the first empty option to act as a placeholder.</td>
 		<td valign="top"><code>boolean</code></td>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -24,6 +24,7 @@ Selectize.defaults = {
 	showEmptyOptionInDropdown: false,
 	emptyOptionLabel: '--',
 	closeAfterSelect: false,
+  closeDropdownThreshold: 250, // number of ms to prevent reopening of dropdown after mousedown
 
 	scrollDuration: 60,
 	deselectBehavior: 'previous', //top, previous

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -41,6 +41,7 @@ var Selectize = function($input, settings) {
 		caretPos         : 0,
 		loading          : 0,
 		loadedSearches   : {},
+    isDropdownClosing: false,
 
 		$activeOption    : null,
 		$activeItems     : [],
@@ -368,6 +369,12 @@ $.extend(Selectize.prototype, {
 	onClick: function(e) {
 		var self = this;
 
+    // if the dropdown is closing due to a mousedown, we don't want to
+    // refocus the element.
+    if (self.isDropdownClosing) {
+      return;
+    }
+
 		// necessary for mobile webkit devices (manual focus triggering
 		// is ignored unless invoked within a click event)
     // also necessary to reopen a dropdown that has been closed by
@@ -398,6 +405,15 @@ $.extend(Selectize.prototype, {
 				if (self.settings.mode === 'single') {
 					// toggle dropdown
 					self.isOpen ? self.close() : self.open();
+
+					// when closing the dropdown, we set a isDropdownClosing
+					// varible temporaily to prevent the dropdown from reopening
+					// from the onClick event
+					self.isDropdownClosing = true;
+					setTimeout(function() {
+						self.isDropdownClosing = false;
+					}, self.settings.closeDropdownThreshold);
+
 				} else if (!defaultPrevented) {
 					self.setActiveItem(null);
 				}


### PR DESCRIPTION
I found an issue with single selects where clicking on the control to close the dropdown reopens the dropdown due to the click event firing after the mousedown closes the dropdown.
I have added a setting of "closeDropdownThreshold" that defaults to 250ms which prevents the "Click" event from running if it is closed via the mousedown event.
If the user wants the previous functionality (close & reopen when clicking the control), this value can be set to 0.