### PR TITLE
Feature : add 'size' option for custom dropdown height

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -23,6 +23,30 @@
       <div class="demo">
 				<h2>&lt;select&gt;</h2>
 				<div class="control-group">
+          <span>Search with any accent : <pre>["à", "è", "ì", "ò", "ù", "À", "È", "Ì", "Ò", "Ù", "á", "é", "í", "ó", "ú", "ý", "Á", "É", "Í", "Ó", "Ú", "Ý", "â", "ê", "î", "ô", "û", "Â", "Ê", "Î", "Ô", "Û", "ã", "ñ", "õ", "Õ", "Ã", "Ñ", "ä", "ë", "ï", "ö", "ü", "ÿ", "Ä", "Ë", "Ï", "Ö", "Ü", "Ÿ", "ç", "Ç", "å", "Å"];</pre></span>
+					<label for="normalize">Beast: Normalize: true / case insensitive</label>
+					<select id="normalize" class="demo-default">
+            <option value=""></option>
+            <option value="1">Awosome</option>
+            <option value="2">Beast</option>
+            <option value="3">Compatible</option>
+            <option value="4">Thomas Edison</option>
+            <option value="5">Nikola</option>
+            <option value="6">Selectize</option>
+            <option value="7">Javascript</option>
+					</select>
+				</div>
+				<script>
+          $('#normalize').selectize({
+            normalize: true
+          });
+
+				</script>
+			</div>
+
+      <div class="demo">
+				<h2>&lt;select&gt;</h2>
+				<div class="control-group">
 					<label for="size-number">Beast: size by items count</label>
 					<select id="size-number" class="demo-default" placeholder="Select a person...">
 						<option value="1">one</option>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -63,7 +63,7 @@
 				</div>
 				<script>
 				$('#size-number').selectize({
-					size: 8
+					dropdownSize: { sizeType: 'numberItems', sizeValue: 8 }
 				});
 				</script>
 			</div>
@@ -87,8 +87,8 @@
 				</div>
 				<script>
 				$('#size-px').selectize({
-					size: '100px'
-				});
+					dropdownSize: { sizeType: 'fixedHeight', sizeValue: 100 }
+        });
 				</script>
 			</div>
 
@@ -110,9 +110,7 @@
 					</select>
 				</div>
 				<script>
-				$('#size-false').selectize({
-					size: false
-				});
+				$('#size-false').selectize();
 				</script>
 			</div>
 

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -20,6 +20,78 @@
 		<div id="wrapper">
 			<h1>Selectize.js</h1>
 
+      <div class="demo">
+				<h2>&lt;select&gt;</h2>
+				<div class="control-group">
+					<label for="size-number">Beast: size by items count</label>
+					<select id="size-number" class="demo-default" placeholder="Select a person...">
+						<option value="1">one</option>
+            <option value="2">two</option>
+            <option value="3">three</option>
+            <option value="4">four</option>
+            <option value="5">five</option>
+            <option value="6">six</option>
+            <option value="7">seven</option>
+            <option value="8">eight</option>
+            <option value="9">nine</option>
+            <option value="10">ten</option>
+					</select>
+				</div>
+				<script>
+				$('#size-number').selectize({
+					size: 8
+				});
+				</script>
+			</div>
+
+      <div class="demo">
+				<h2>&lt;select&gt;</h2>
+				<div class="control-group">
+					<label for="size-px">Beast: size by px height (also available with rem, em, vh)</label>
+					<select id="size-px" class="demo-default" placeholder="Select a person...">
+						<option value="1">one</option>
+            <option value="2">two</option>
+            <option value="3">three</option>
+            <option value="4">four</option>
+            <option value="5">five</option>
+            <option value="6">six</option>
+            <option value="7">seven</option>
+            <option value="8">eight</option>
+            <option value="9">nine</option>
+            <option value="10">ten</option>
+					</select>
+				</div>
+				<script>
+				$('#size-px').selectize({
+					size: '100px'
+				});
+				</script>
+			</div>
+
+      <div class="demo">
+				<h2>&lt;select&gt;</h2>
+				<div class="control-group">
+					<label for="size-false">Beast: size false (auto)</label>
+					<select id="size-false" class="demo-default" placeholder="Select a person...">
+						<option value="1">one</option>
+            <option value="2">two</option>
+            <option value="3">three</option>
+            <option value="4">four</option>
+            <option value="5">five</option>
+            <option value="6">six</option>
+            <option value="7">seven</option>
+            <option value="8">eight</option>
+            <option value="9">nine</option>
+            <option value="10">ten</option>
+					</select>
+				</div>
+				<script>
+				$('#size-false').selectize({
+					size: false
+				});
+				</script>
+			</div>
+
 			<div class="demo">
 				<h2>&lt;input type="text"&gt;</h2>
 				<div class="control-group">

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -54,7 +54,10 @@ Selectize.defaults = {
 	dropdownParent: null,
 
 	copyClassesToDropdown: true,
-  size: false, // must be a number items displayed or height (px, em, rem, vh)
+  dropdownSize: {
+    sizeType: 'auto', // 'numberItems' or 'fixedHeight'
+    sizeValue: 'auto', // number of items or height value (px is default) or CSS height (px, rem, em, vh)
+  },
   normalize: false,
 	/*
 	load                 : null, // function(query, callback) { ... }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -55,6 +55,7 @@ Selectize.defaults = {
 
 	copyClassesToDropdown: true,
   size: false, // must be a number items displayed or height (px, em, rem, vh)
+  normalize: false,
 	/*
 	load                 : null, // function(query, callback) { ... }
 	score                : null, // function(search) { ... }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -54,7 +54,7 @@ Selectize.defaults = {
 	dropdownParent: null,
 
 	copyClassesToDropdown: true,
-
+  size: false, // must be a number items displayed or height (px, em, rem, vh)
 	/*
 	load                 : null, // function(query, callback) { ... }
 	score                : null, // function(search) { ... }

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1091,7 +1091,8 @@ $.extend(Selectize.prototype, {
 		}
 
 		// perform search
-		if (query !== self.lastQuery) {
+    if (query !== self.lastQuery) {
+      if (settings.normalize) query = query.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 			self.lastQuery = query;
 			result = self.sifter.search(query, $.extend(options, {score: calculateScore}));
 			self.currentResults = result;

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1959,10 +1959,10 @@ $.extend(Selectize.prototype, {
 	},
 
   setupDropdownHeight: function () {
-    if (this.settings.size) {
-      var height = this.settings.size;
+    if (typeof this.settings.dropdownSize === 'object' && this.settings.dropdownSize.sizeType !== 'auto') {
+      var height = this.settings.dropdownSize.sizeValue;
 
-      if (!isNaN(height)) {
+      if (this.settings.dropdownSize.sizeType === 'numberItems') {
         var $items = this.$dropdown_content.children();
         var totalHeight = 0;
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1904,7 +1904,8 @@ $.extend(Selectize.prototype, {
 		self.focus();
 		self.isOpen = true;
 		self.refreshState();
-		self.$dropdown.css({visibility: 'hidden', display: 'block'});
+    self.$dropdown.css({ visibility: 'hidden', display: 'block' });
+    self.setupDropdownHeight();
 		self.positionDropdown();
 		self.$dropdown.css({visibility: 'visible'});
 		self.trigger('dropdown_open', self.$dropdown);
@@ -1955,6 +1956,29 @@ $.extend(Selectize.prototype, {
 			left  : offset.left
 		});
 	},
+
+  setupDropdownHeight: function () {
+    if (this.settings.size) {
+      var height = this.settings.size;
+
+      if (!isNaN(height)) {
+        var $items = this.$dropdown_content.children();
+        var totalHeight = 0;
+
+        $items.each(function (i, $item) {
+          if (i === height) return false;
+
+          totalHeight += $($item).outerHeight(true);
+        });
+
+        // Get padding top for subtract to global height to avoid seeing the next item
+        var padding = this.$dropdown_content.css('padding-top') ? this.$dropdown_content.css('padding-top').replace(/\W*(\w)\w*/g, '$1') : 0;
+        height = (totalHeight - padding) + 'px';
+      }
+
+      this.$dropdown_content.css({ height: height, maxHeight: 'none' });
+    }
+  },
 
 	/**
 	 * Resets / clears all selected items

--- a/test/setup.js
+++ b/test/setup.js
@@ -413,7 +413,7 @@
 					'<option value="b">B</option>' +
 					'<option value="c">C</option>' +
 				'</select>', {
-					size: 1
+          dropdownSize: { sizeType: 'numberItems', sizeValue: 1 }
 				});
 			});
 
@@ -437,11 +437,11 @@
 					'<option value="">Select an option...</option>' +
 					'<option value="a">A</option>' +
 				'</select>', {
-					size: '100px'
+          dropdownSize: { sizeType: 'fixedHeight', sizeValue: 100 }
 				});
 			});
 
-			it('should dropdown height to be equal 100px', function(done) {
+			it('should dropdown height to be equal 100', function(done) {
 				test.selectize.focus();
 
 				window.setTimeout(function () {

--- a/test/setup.js
+++ b/test/setup.js
@@ -403,6 +403,54 @@
 			});
 		});
 
+    describe('<select> custom size (number)', function() {
+			var test;
+
+			beforeEach(function() {
+				test = setup_test('<select>' +
+					'<option value="">Select an option...</option>' +
+					'<option value="a">A</option>' +
+					'<option value="b">B</option>' +
+					'<option value="c">C</option>' +
+				'</select>', {
+					size: 1
+				});
+			});
+
+			it('should adapt dropdown height', function(done) {
+				test.selectize.focus();
+
+        window.setTimeout(function () {
+          var padding = test.selectize.$dropdown_content.css('padding-top') ? test.selectize.$dropdown_content.css('padding-top').replace(/\W*(\w)\w*/g, '$1') : 0;
+          var heightExpected = test.selectize.$dropdown_content.find('.option').first().outerHeight(true) - padding;
+					expect(test.selectize.$dropdown_content.height()).to.be.equal(heightExpected);
+					done();
+				}, 0);
+			});
+    });
+
+    describe('<select> custom size (css height)', function() {
+			var test;
+
+			beforeEach(function() {
+				test = setup_test('<select>' +
+					'<option value="">Select an option...</option>' +
+					'<option value="a">A</option>' +
+				'</select>', {
+					size: '100px'
+				});
+			});
+
+			it('should dropdown height to be equal 100px', function(done) {
+				test.selectize.focus();
+
+				window.setTimeout(function () {
+					expect(test.selectize.$dropdown_content.height()).to.be.equal(100);
+					done();
+				}, 0);
+			});
+		});
+
 	});
 
 })();


### PR DESCRIPTION
new 'size' option to set dropdown size, can be a number to displayed items, or a simple CSS height (px, rem, em, vh)

I also added two tests for value as number of items displayed and CSS value

Default value is `false` so nothing change

Open to improvement and patch