### PR TITLE
Missing reset for select element.

### DIFF
--- a/src/scss/selectize.bootstrap5.scss
+++ b/src/scss/selectize.bootstrap5.scss
@@ -158,6 +158,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
   }
 }
 
+.form-select.#{$selectize}-control,
 .form-control.#{$selectize}-control {
   padding: 0;
   height: auto;


### PR DESCRIPTION
Missing reset for select element that has a `form-select` class. Useful when using `selectize()` on a `<select>` element.