### PR TITLE
Accessibility: measureString: hide temporary element from screen reader

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -264,6 +264,8 @@ var measureString = function (str, $parent) {
       width: 0,
       height: 0,
       overflow: 'hidden'
+    }).attr({
+      'aria-hidden': true
     }).append(Selectize.$testInput).appendTo('body');
   }
 


### PR DESCRIPTION
The temporary element used by `measureString` is left in the document for future use.
However, while it is hidden visually, it will be visible to screen readers.
This PR adds the `aria-hidden` attribute which has no effect other than hiding it from screen readers.

Tested with NVDA 2022.3.2 and Firefox 107 on Windows 10.