### PR TITLE
fix(a11y): blur when tabbing out of input

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -218,8 +218,8 @@ $.extend(Selectize.prototype, {
 			keypress  : function() { return self.onKeyPress.apply(self, arguments); },
 			input     : function() { return self.onInput.apply(self, arguments); },
 			resize    : function() { self.positionDropdown.apply(self, []); },
-			// blur      : function() { return self.onBlur.apply(self, arguments); },
-			focus     : function() { self.ignoreBlur = false; return self.onFocus.apply(self, arguments); },
+			blur      : function() { return self.onBlur.apply(self, arguments); },
+			focus     : function() { return self.onFocus.apply(self, arguments); },
 			paste     : function() { return self.onPaste.apply(self, arguments); }
 		});
 
@@ -243,7 +243,12 @@ $.extend(Selectize.prototype, {
 				}
 				// blur on click outside
 				// do not blur if the dropdown is clicked
-				if (!self.$dropdown.has(e.target).length && e.target !== self.$control[0]) {
+				if (self.$dropdown.has(e.target).length) {
+					self.ignoreBlur = true;
+					window.setTimeout(function() {
+						self.ignoreBlur = false;
+					}, 0);
+				} else if (e.target !== self.$control[0]) {
 					self.blur(e.target);
 				}
 			}
@@ -685,19 +690,17 @@ $.extend(Selectize.prototype, {
 	 */
 	onBlur: function(e, dest) {
 		var self = this;
+
+		if (self.ignoreBlur) {
+			return;
+		}
+
 		if (!self.isFocused) return;
 		self.isFocused = false;
 
 		if (self.ignoreFocus) {
 			return;
 		}
-		// Bug fix do not blur dropdown here
-		// else if (!self.ignoreBlur && document.activeElement === self.$dropdown_content[0]) {
-		// 	// necessary to prevent IE closing the dropdown when the scrollbar is clicked
-		// 	self.ignoreBlur = true;
-		// 	self.onFocus(e);
-		// 	return;
-		// }
 
 		var deactivate = function() {
 			self.close();

--- a/test/api.js
+++ b/test/api.js
@@ -633,7 +633,7 @@
 					test.selectize.search('hello');
 				}).to.not.throw(Error);
       });
-      it('should normalize a string', function () {
+      expect('should normalize a string', function () {
         var test;
 
         beforeEach(function() {
@@ -642,11 +642,12 @@
           '</select>', { normalize: true });
         });
 
-        it('should return query satinized', function() {
+        it('should return query satinized', function(done) {
           var query = test.selectize.search('héllo').query;
 
           window.setTimeout(function () {
             expect(query).to.be.equal('hello');
+            done();
           }, 0);
         });
 			});


### PR DESCRIPTION
Fixes #1926.
To be accessible, it should be possible to easily navigate elements using the keyboard.
Previously, when using TAB to navigate through form elements, the input would enter its focused state when focused with TAB (and the dropdown would open when using `openOnFocus`).
However, when TAB is used to jump to the next focusable element, it would not lose its focused state, and the dropdown would stay open. This commit restores the behavior before #1813 and ensures that the input leaves its focused state and closes the dropdown when blurred using TAB.