### PR TITLE
Allow JSON as value select options

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1925,7 +1925,7 @@ $.extend(Selectize.prototype, {
 			old = existing.filter(function(value) {
 				return values.indexOf(value) < 0;
 			}).map(function(value) {
-				return 'option[value="' + value + '"]';
+				return 'option[value="' + escape_html(value) + '"]';
 			});
 
 			if (existing.length - old.length + fresh.length === 0 && !self.$input.attr('multiple')) {

--- a/test/api.js
+++ b/test/api.js
@@ -530,7 +530,7 @@
 						{value: 0},
 						{value: 1},
 						{value: 2},
-						{value: 3},
+						{value: JSON.stringify({"type":"place"})},
 					],
 					items: ['1','2','3']
 				});
@@ -549,7 +549,7 @@
 				// 		{value: 0},
 				// 		{value: 1},
 				// 		{value: 2},
-				// 		{value: 3},
+				// 		{value: JSON.stringify({"type":"place"})},
 				// 	],
 				// 	items: ['1','2','3']
 				// });
@@ -561,7 +561,7 @@
 					window.setTimeout(function() {
 						expect(test.selectize.$dropdown_content.find('[data-value=1]').length).to.be.equal(1);
 						expect(test.selectize.$dropdown_content.find('[data-value=2]').length).to.be.equal(1);
-						expect(test.selectize.$dropdown_content.find('[data-value=3]').length).to.be.equal(1);
+						expect(test.selectize.$dropdown_content.find('[data-value*="type"]').length).to.be.equal(1);
 						done();
 					}, 0);
 				}, 0);
@@ -574,7 +574,7 @@
 				test.selectize.clear();
 				expect(test.selectize.$control.find('[data-value=1]').length).to.be.equal(0);
 				expect(test.selectize.$control.find('[data-value=2]').length).to.be.equal(0);
-				expect(test.selectize.$control.find('[data-value=3]').length).to.be.equal(0);
+				expect(test.selectize.$control.find('[data-value*="type"]').length).to.be.equal(0);
 			});
 			it('should not fire "change" if silent is truthy', function(done) {
 				var watcher = function(e) { throw new Error('Change fired'); };


### PR DESCRIPTION
Hello everyone:

I'm using selectize and I've found something that could be a "bug". In my select I use JSON like:
```
{"type":"place","name":"place_name for l 0","latitude":-27.7705,"longitude":-21.4252,"approxLocation":"city for l 0, province for l 0, country for l 0"}
```
for setting it as value in the option html tag.

The problem is that this line breaks because does not support it, it worked in v0.12.2.

Do you think this is ok?