### PR TITLE
fix(a11y): keep focus on input after selecting an dropdown item

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -692,6 +692,9 @@ $.extend(Selectize.prototype, {
 		var self = this;
 
 		if (self.ignoreBlur) {
+			if (self.isFocused) {
+				self.focus();
+			}
 			return;
 		}
 


### PR DESCRIPTION
Fixes second example of #1926.
To be accessible, it should be possible to keep using the input easily after selecting and item on multi-select input.
Previously, when using mousedown to pick an item from the dropdown, the input would lose focus and ignoring blur wasn't enough in order to keep the input focused.