### PR TITLE
simplify not blurring control when clicking on dropdown

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -237,18 +237,15 @@ $.extend(Selectize.prototype, {
 
 		$document.on('mousedown' + eventNS, function(e) {
 			if (self.isFocused) {
-				// prevent events on the dropdown scrollbar from causing the control to blur
-				if (e.target === self.$dropdown[0] || e.target.parentNode === self.$dropdown[0]) {
+				// prevent events on the dropdown from causing the control to blur
+				if (
+					e.target === self.$dropdown[0] ||
+					self.$dropdown.has(e.target).length)
+				{
 					return false;
 				}
 				// blur on click outside
-				// do not blur if the dropdown is clicked
-				if (self.$dropdown.has(e.target).length) {
-					self.ignoreBlur = true;
-					window.setTimeout(function() {
-						self.ignoreBlur = false;
-					}, 0);
-				} else if (e.target !== self.$control[0]) {
+				if (e.target !== self.$control[0]) {
 					self.blur(e.target);
 				}
 			}
@@ -690,10 +687,6 @@ $.extend(Selectize.prototype, {
 	 */
 	onBlur: function(e, dest) {
 		var self = this;
-
-		if (self.ignoreBlur) {
-			return;
-		}
 
 		if (!self.isFocused) return;
 		self.isFocused = false;


### PR DESCRIPTION
Avoid control getting blurred on `mousedown` events on the dropdown. Fixes #1926

I've tested this change and I've not found any issue and I couldn't figure out any reason why not to prevent the `mousedown` event when it occurs in the dropdown, now that selecting `onOptionSelect` and `onItemSelect` happens on `mouseup` events.