### PR TITLE
feat: add option 'showArrow' and fix input/dropdown width

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -63,6 +63,7 @@ Selectize.defaults = {
 
   ignoreOnDropwdownHeight: 'img, i',
   search: true,
+  showArrow: true,
 
   /*
   load                 : null, // function(query, callback) { ... }

--- a/src/plugins/auto_position/plugin.js
+++ b/src/plugins/auto_position/plugin.js
@@ -21,8 +21,9 @@ Selectize.define("auto_position", function () {
           controlPosBottom - dropdownHeight - wrapperHeight >= 0 ?
           POSITION.top :
           POSITION.bottom;
+      const w = this.$wrapper[0].style.width !== 'fit-content' ? '100%' : 'max-content';
       const styles = {
-        width: $control.outerWidth(),
+        width: w,
         left: offset.left
       };
 
@@ -43,6 +44,12 @@ Selectize.define("auto_position", function () {
       }
 
       this.$dropdown.css(styles);
+
+      if (w === 'max-content' && $control[0].getBoundingClientRect().width >= this.$dropdown[0].getBoundingClientRect().width) {
+        this.$dropdown.css({
+          width : '100%'
+        });
+      }
     };
   }());
 });

--- a/src/scss/selectize.scss
+++ b/src/scss/selectize.scss
@@ -340,7 +340,7 @@ $select-spinner-border-color: $select-color-border;
     cursor: text;
   }
 
-  &:after {
+  &:not(.no-arrow):after {
     content: " ";
     display: block;
     position: absolute;
@@ -353,7 +353,7 @@ $select-spinner-border-color: $select-color-border;
     border-width: $select-arrow-size $select-arrow-size 0 $select-arrow-size;
     border-color: $select-arrow-color transparent transparent transparent;
   }
-  &.dropdown-active:after {
+  &:not(.no-arrow).dropdown-active:after {
     margin-top: $select-arrow-size * -0.8;
     border-width: 0 $select-arrow-size $select-arrow-size $select-arrow-size;
     border-color: transparent transparent $select-arrow-color transparent;

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -129,12 +129,14 @@ $.extend(Selectize.prototype, {
 		var classes;
 		var classes_plugins;
 		var inputId;
+    var noArrowClass;
 
 		inputMode         = self.settings.mode;
-		classes           = $input.attr('class') || '';
+    classes           = $input.attr('class') || '';
+    noArrowClass      = settings.showArrow ? '' : ' no-arrow';
 
     $wrapper          = $('<div>').addClass(settings.wrapperClass).addClass(classes + ' selectize-control').addClass(inputMode);
-		$control          = $('<div>').addClass(settings.inputClass + ' selectize-input items').appendTo($wrapper);
+		$control          = $('<div>').addClass(settings.inputClass + noArrowClass + ' selectize-input items').appendTo($wrapper);
 		$control_input    = $('<input type="text" autocomplete="new-password" autofill="no" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 		$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 		$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode + ' selectize-dropdown').hide().appendTo($dropdown_parent);

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -172,7 +172,7 @@ $.extend(Selectize.prototype, {
     // to have an identical rendering to a simple select (usefull for mobile device and do not open keyboard)
     if (!self.settings.search) {
       $control_input.attr('readonly', true);
-	  $control_input.attr('inputmode', 'none');
+	    $control_input.attr('inputmode', 'none');
       $control.css('cursor', 'pointer');
     }
 
@@ -2013,7 +2013,7 @@ $.extend(Selectize.prototype, {
 		var $control = this.$control;
 		var offset = this.settings.dropdownParent === 'body' ? $control.offset() : $control.position();
 		offset.top += $control.outerHeight(true);
-		var w = $control[0].getBoundingClientRect().width;
+		var w = this.$wrapper[0].style.width !== 'fit-content' ? '100%' : 'max-content';
 		if (this.settings.minWidth && this.settings.minWidth > w)
 		{
 			w = this.settings.minWidth;
@@ -2023,6 +2023,12 @@ $.extend(Selectize.prototype, {
 			top   : offset.top,
 			left  : offset.left
 		});
+
+    if (w === 'max-content' && $control[0].getBoundingClientRect().width >= this.$dropdown[0].getBoundingClientRect().width) {
+      this.$dropdown.css({
+        width : '100%'
+      });
+    }
 	},
 
   setupDropdownHeight: function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -333,14 +333,15 @@ var autoGrow = function ($input) {
       }
     }
 
+    var width = $input.attr('readonly') ? 0 : 4;
     placeholder = $input.attr('placeholder');
     if (placeholder) {
-      placeholderWidth = measureString(placeholder, $input) + 4;
+      placeholderWidth = measureString(placeholder, $input) + width;
     } else {
       placeholderWidth = 0;
     }
 
-    width = Math.max(measureString(value, $input), placeholderWidth) + 4;
+    width = Math.max(measureString(value, $input), placeholderWidth) + width;
     if (width !== currentWidth) {
       currentWidth = width;
       $input.width(width);


### PR DESCRIPTION
Add option for can hide arrow if we want 
Fix dropdown width when 'fit-content' set to `<select>` or `<input>` 
Fix input width when `readonly` for not resizing input and not set useless width to `<input>` 