### PR TITLE
fix: ensure the parent of $testInput exists within the body

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -266,9 +266,10 @@ var measureString = function (str, $parent) {
       overflow: 'hidden'
     }).attr({
       'aria-hidden': true
-    }).append(Selectize.$testInput).appendTo('body');
+    }).append(Selectize.$testInput);
   }
 
+  Selectize.$testInput.parent().appendTo('body');
   Selectize.$testInput.text(str);
 
   transferStyles($parent, Selectize.$testInput, [


### PR DESCRIPTION
In some scenarios of using SPA, measureString can correctly calculate the width of $testInput on the first call. However, due to various possibilities, changes to the DOM will cause $testInput to leave the body, and the calculation result of measureString will always be 0. This PR ensures that $testInput always exists under the body to calculate the correct width.

The following is a rough example of reproducing the bug:
```js
// Append $testInput to the body
$("input").appendTo("body").selectize(); 

// $testInput leaves the body
$("body").html(""); 

// measureString gets incorrect results
$("input").appendTo("body").selectize(); 
```