### PR TITLE
Fix of deprecation in bootstrap4 theme with sass 1.63.3

### DIFF
--- a/lib/bootstrap4/vendor/_rfs.scss
+++ b/lib/bootstrap4/vendor/_rfs.scss
@@ -79,15 +79,15 @@ $rfs-breakpoint-unit-cache: unit($rfs-breakpoint);
 
     // Remove px-unit from $fs for calculations
     @if $fs-unit == "px" {
-      $fs: $fs / ($fs * 0 + 1);
+      $fs: calc($fs / ($fs * 0 + 1));
     }
     @else if $fs-unit == "rem" {
-      $fs: $fs / ($fs * 0 + calc(1 / $rfs-rem-value));
+      $fs: calc($fs / (1 / $rfs-rem-value));
     }
 
     // Set default font-size
     @if $rfs-font-size-unit == rem {
-      $rfs-static: #{$fs / $rfs-rem-value}rem#{$rfs-suffix};
+      $rfs-static: #{calc($fs / $rfs-rem-value)}rem#{$rfs-suffix};
     }
     @else if $rfs-font-size-unit == px {
       $rfs-static: #{$fs}px#{$rfs-suffix};


### PR DESCRIPTION
Fixing these two deprecation warnings:

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($fs, $fs * 0 + calc(1 / $rfs-rem-value)) or calc($fs / ($fs * 0 + calc(1 / $rfs-rem-value)))

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
85 │       $fs: $fs / ($fs * 0 + calc(1 / $rfs-rem-value));
   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@selectize/selectize/dist/lib/bootstrap4/vendor/_rfs.scss 85:12      rfs()
    node_modules/@selectize/selectize/dist/lib/bootstrap4/vendor/_rfs.scss 199:3      font-size()
    node_modules/@selectize/selectize/dist/lib/bootstrap4/mixins/_buttons.scss 106:3  button-size()
    src/scss/custom.scss 48:5                                                         @import
    src/scss/gui.scss 116:9                                                           root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($fs, $rfs-rem-value) or calc($fs / $rfs-rem-value)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
90 │       $rfs-static: #{$fs / $rfs-rem-value}rem#{$rfs-suffix};
   │                      ^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@selectize/selectize/dist/lib/bootstrap4/vendor/_rfs.scss 90:22      rfs()
    node_modules/@selectize/selectize/dist/lib/bootstrap4/vendor/_rfs.scss 199:3      font-size()
    node_modules/@selectize/selectize/dist/lib/bootstrap4/mixins/_buttons.scss 106:3  button-size()
    src/scss/custom.scss 48:5                                                         @import
    src/scss/gui.scss 116:9                                                           root stylesheet
```