### PR TITLE
Fixed keeping the order when selecting a new option between other options by the keyboard navigation

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1940,7 +1940,9 @@ $.extend(Selectize.prototype, {
 			}
 
 			self.$input.find(old.join(', ')).remove();
-			self.$input.append(fresh.join(''));
+			$(fresh.join('')).each(function() {
+				self.$input[0].insertBefore(this, self.$input[0].childNodes[self.caretPos - 1]);
+			})
 		} else {
 			self.$input.val(self.getValue());
 			self.$input.attr('value',self.$input.val());


### PR DESCRIPTION
Keyboard navigation allows us to insert a new option between other selected options.
Unfortunately existing logic adds the new option to the end of the list of selected options.

This problem may be visible in the [selectize example](https://selectize.dev/docs/demos/opt-groups): the new \<option> adds to the very end in the \<select> tag.