### PR TITLE
Fix relative library path in scss

### DIFF
--- a/src/scss/selectize.bootstrap3.scss
+++ b/src/scss/selectize.bootstrap3.scss
@@ -1,5 +1,5 @@
-@import "lib/bootstrap-sass/variables";
-@import "lib/bootstrap-sass/mixins/_nav-divider";
+@import "../lib/bootstrap-sass/variables";
+@import "../lib/bootstrap-sass/mixins/_nav-divider";
 
 $select-font-family: inherit;
 $select-font-size: inherit;

--- a/src/scss/selectize.bootstrap4.scss
+++ b/src/scss/selectize.bootstrap4.scss
@@ -1,6 +1,6 @@
-@import "lib/bootstrap4/functions";
-@import "lib/bootstrap4/variables";
-@import "lib/bootstrap4/mixins";
+@import "../lib/bootstrap4/functions";
+@import "../lib/bootstrap4/variables";
+@import "../lib/bootstrap4/mixins";
 
 $enable-shadows: true !default;
 $select-font-family: inherit !default;

--- a/src/scss/selectize.bootstrap5.scss
+++ b/src/scss/selectize.bootstrap5.scss
@@ -1,6 +1,6 @@
-@import "lib/bootstrap5/functions";
-@import "lib/bootstrap5/variables";
-@import "lib/bootstrap5/mixins";
+@import "../lib/bootstrap5/functions";
+@import "../lib/bootstrap5/variables";
+@import "../lib/bootstrap5/mixins";
 
 $enable-shadows: true !default;
 $select-font-family: inherit !default;


### PR DESCRIPTION
Importing the bootstrap scss styles fails in all 3 versions of bootstrap, since the library path is one level below the scss path.