### PR TITLE
Right-pad dropdown text to prevent overlap with arrow

### DIFF
--- a/dist/scss/selectize.scss
+++ b/dist/scss/selectize.scss
@@ -143,6 +143,7 @@ $select-spinner-border-color: $select-color-border;
     vertical-align: baseline;
     display: inline-block;
     zoom: 1;
+    padding-right: 1em;
   }
   .#{$selectize}-control.multi & > div {
     cursor: pointer;

--- a/dist/scss/selectize.scss
+++ b/dist/scss/selectize.scss
@@ -143,6 +143,7 @@ $select-spinner-border-color: $select-color-border;
     vertical-align: baseline;
     display: inline-block;
     zoom: 1;
+	padding-right: 1em;
   }
   .#{$selectize}-control.multi & > div {
     cursor: pointer;


### PR DESCRIPTION
When the text inside a dropdown is quite long, it is possible for it to obscure the arrow that indicates this is a dropdown menu. This can look somewhat unpolished.

I included a padding-right statement to preserve the bit of space that the arrow occupies.
Below is an example of a dropdown before and after this change.

<img width="156" alt="selectize_rpad_arrow" src="https://github.com/selectize/selectize.js/assets/111303584/9cf09e7c-0ed3-4562-8913-5f1fd2ad6020">
